### PR TITLE
fix typo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 DOC_URL=https://support.hypernode.com/en/ecommerce/magento-1/how-to-enable-mysql-query-logging-for-magento-1-x
-bin/download_doc --output-dir=docs/ecommerce_applications $DOC_URL
+bin/download_doc --output-dir=docs/ecommerce-applications $DOC_URL
 ```
 
 ## Installing dependencies


### PR DESCRIPTION
ran into:
```
hypernode-docs-next]$ bin/download_doc --output-dir=docs/ecommerce_applications $DOC_URL
Output directory docs/ecommerce_applications does not exist!
```
(but maybe I was doing it wrong). this worked for me