### PR TITLE
add article about shopware6 and basic auth

### DIFF
--- a/docs/ecommerce-applications/shopware-6/admin-loop-in-shopware-6-when-basic-auth-is-used.md
+++ b/docs/ecommerce-applications/shopware-6/admin-loop-in-shopware-6-when-basic-auth-is-used.md
@@ -1,0 +1,21 @@
+Admin loop in Shopware 6 when basic auth is used
+================================================
+
+On a Hypernode dev plan basic auth is enabled out of the box. You can also configure Nginx to put your site or parts of your site behind basic auth on a production plan. When you want to use Shopware 6 on a Hypernode with basic auth you need to take into account that Shopware overwrites the Authorization header.
+
+Shopware uses OAuth with a bearer token for logging into the admin and using the API. For example if your shop is `http://<appname>.hypernode.io/`, that URL will work fine. But logging in to `http://<appname>.hypernode.io/admin/` will send you into a basic auth loop.
+
+The solution is to whitelist your IP to skip the basic auth on the Hypernode when you come from your specified IP.
+
+```bash
+$ cat /data/web/nginx/whitelist-development-exception.conf 
+# You can make certain IP addresses exempt here from the development
+# basic auth. Beware though, that google and bing bots will always
+# remain blocked on development nodes!
+
+geo $development_exceptions {
+	default "Development restricted area";
+        # The IP that you want to access the Shopware 6 admin from
+        1.2.3.4 "off"; 
+}
+```


### PR DESCRIPTION
wrote this up and had this stored somewhere in a markdown file
after we had a support case where this was the issue, hadn't bothered to
put this on the normal support documentation because that wysiwyg
stuff is such a hassle.

Looks like:
![screencapture-localhost-8000-ecommerce-applications-shopware-6-admin-loop-in-shopware-6-when-basic-auth-is-used-html-2022-04-10-19_54_00](https://user-images.githubusercontent.com/1437341/162632789-a9e42799-bd87-4c0b-b56b-5cef044c874a.png)
