### PR TITLE
style: Improve code blocks formatting

### DIFF
--- a/docs/_static/css/general.css
+++ b/docs/_static/css/general.css
@@ -145,18 +145,13 @@ h2 {
   line-height: auto;
 }
 
-.rst-content section ul li {
-  list-style: none;
-}
-
-ul.simple li p {
-  line-height: 40px;
-}
-
 code,
 pre,
 pre span,
-span.pre {
+span.pre,
+.rst-content .linenodiv pre,
+.rst-content div[class^=highlight] pre,
+.rst-content pre.literal-block {
   font-family: "Ubuntu Mono", monospace;
 }
 
@@ -164,7 +159,6 @@ ul.simple li code,
 code.docutils.literal.notranslate {
   border: none;
   width: max-content;
-  font-weight: 500;
   font-size: 13px;
   padding: 10px;
   margin: 10px 0;
@@ -189,7 +183,6 @@ code.docutils.literal.notranslate.literal {
 }
 .rst-content div.notranslate .highlight {
   font-family: "Ubuntu Mono", monospace;
-  font-weight: 500;
   font-size: 16px;
   padding: 10px;
   line-height: 24px;

--- a/docs/_static/css/main.css
+++ b/docs/_static/css/main.css
@@ -169,18 +169,13 @@ h2 {
   line-height: auto;
 }
 
-.rst-content section ul li {
-  list-style: none;
-}
-
-ul.simple li p {
-  line-height: 40px;
-}
-
 code,
 pre,
 pre span,
-span.pre {
+span.pre,
+.rst-content .linenodiv pre,
+.rst-content div[class^=highlight] pre,
+.rst-content pre.literal-block {
   font-family: "Ubuntu Mono", monospace;
 }
 
@@ -188,7 +183,6 @@ ul.simple li code,
 code.docutils.literal.notranslate {
   border: none;
   width: max-content;
-  font-weight: 500;
   font-size: 13px;
   padding: 10px;
   margin: 10px 0;
@@ -213,7 +207,6 @@ code.docutils.literal.notranslate.literal {
 }
 .rst-content div.notranslate .highlight {
   font-family: "Ubuntu Mono", monospace;
-  font-weight: 500;
   font-size: 16px;
   padding: 10px;
   line-height: 24px;

--- a/docs/_static/pygments.css
+++ b/docs/_static/pygments.css
@@ -1,0 +1,71 @@
+/*! Github Dark (Native mod) theme; http://blog.favrik.com/2011/02/22/preview-all-pygments-styles-for-your-code-highlighting-needs/#stylesheetNavigator */
+.highlight, .highlight pre, .highlight table { background: #111 !important; color: #d0d0d0 !important; }
+.highlight .hll { background-color: #404040 !important; }
+.highlight .c { color: #3677a9 !important; } /* Comment */
+.highlight .err { color: #a61717 !important; background-color: #311 !important; } /* Error */
+.highlight .g { color: #d0d0d0 !important; } /* Generic */
+.highlight .k { color: #ccc !important; } /* Keyword; catches prefixes and css3 */
+.highlight .l { color: #d0d0d0 !important; } /* Literal */
+.highlight .n, .highlight .h { color: #ccc !important; } /* Name */
+.highlight .o { color: #777 !important; } /* Operator */
+.highlight .x { color: #d0d0d0 !important; } /* Other */
+.highlight .p { color: #E9B96E !important; } /* Punctuation */
+.highlight .cm { color: #3677a9 !important; } /* Comment.Multiline */
+.highlight .cp { color: #D2691E !important; } /* Comment.Preproc */
+.highlight .c1 { color: #3677a9 !important; } /* Comment.Single */
+.highlight .cs { color: #e50808 !important; background-color: #520000 !important; } /* Comment.Special */
+.highlight .gd { color: #d22323 !important; } /* Generic.Deleted */
+.highlight .ge { color: #d0d0d0 !important; } /* Generic.Emph */
+.highlight .gr { color: #d22323 !important; } /* Generic.Error */
+.highlight .gh { color: #ffffff !important; } /* Generic.Heading */
+.highlight .gi { color: #589819 !important; } /* Generic.Inserted */
+.highlight .go { color: #cccccc !important; } /* Generic.Output */
+.highlight .gp { color: #aaaaaa !important; } /* Generic.Prompt */
+.highlight .gs { color: #d0d0d0 !important; } /* Generic.Strong */
+.highlight .gu { color: #ffffff !important; } /* Generic.Subheading */
+.highlight .gt { color: #d22323 !important; } /* Generic.Traceback */
+.highlight .kc { color: #6ab825 !important; } /* Keyword.Constant */
+.highlight .kd { color: #6ab825 !important; } /* Keyword.Declaration */
+.highlight .kn { color: #6ab825 !important; } /* Keyword.Namespace */
+.highlight .kp { color: #6ab825 !important; } /* Keyword.Pseudo */
+.highlight .kr { color: #6ab825 !important; } /* Keyword.Reserved */
+.highlight .kt { color: #6ab825 !important; } /* Keyword.Type */
+.highlight .ld { color: #d0d0d0 !important; } /* Literal.Date */
+.highlight .m { color: #cd2828 !important; } /* Literal.Number */
+.highlight .s { color: #D2691E !important; } /* Literal.String */
+.highlight .na { color: #bbbbbb !important; } /* Name.Attribute */
+.highlight .nb { color: #24909d !important; } /* Name.Builtin */
+.highlight .nc { color: #447fcf !important; } /* Name.Class */
+.highlight .no { color: #4ca !important; } /* Name.Constant */
+.highlight .nd { color: #ffa500 !important; } /* Name.Decorator */
+.highlight .ni { color: #d0d0d0 !important; } /* Name.Entity */
+.highlight .ne { color: #bbbbbb !important; } /* Name.Exception */
+.highlight .nf { color: #098 !important; } /* Name.Function */
+.highlight .nl { color: #d0d0d0 !important; } /* Name.Label */
+.highlight .nn { color: #447fcf !important; } /* Name.Namespace */
+.highlight .nx { color: #d0d0d0 !important; } /* Name.Other */
+.highlight .py { color: #d0d0d0 !important; } /* Name.Property */
+.highlight .nt { color: #6ab825 !important; } /* Name.Tag */
+.highlight .nv { color: #4ca !important; } /* Name.Variable */
+.highlight .ow { color: #6ab825 !important; } /* Operator.Word */
+.highlight .w { color: #666666 !important; } /* Text.Whitespace */
+.highlight .mf { color: #cd2828 !important; } /* Literal.Number.Float */
+.highlight .mh { color: #cd2828 !important; } /* Literal.Number.Hex */
+.highlight .mi { color: #cd2828 !important; } /* Literal.Number.Integer */
+.highlight .mo { color: #cd2828 !important; } /* Literal.Number.Oct */
+.highlight .sb { color: #D2691E !important; } /* Literal.String.Backtick */
+.highlight .sc { color: #D2691E !important; } /* Literal.String.Char */
+.highlight .sd { color: #D2691E !important; } /* Literal.String.Doc */
+.highlight .s2 { color: #D2691E !important; } /* Literal.String.Double */
+.highlight .se { color: #D2691E !important; } /* Literal.String.Escape */
+.highlight .sh { color: #D2691E !important; } /* Literal.String.Heredoc */
+.highlight .si { color: #D2691E !important; } /* Literal.String.Interpol */
+.highlight .sx { color: #ffa500 !important; } /* Literal.String.Other */
+.highlight .sr { color: #cd2828 !important; } /* Literal.String.Regex */
+.highlight .s1 { color: #D2691E !important; } /* Literal.String.Single */
+.highlight .ss { color: #D2691E !important; } /* Literal.String.Symbol */
+.highlight .bp { color: #24909d !important; } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #4ca !important; } /* Name.Variable.Class */
+.highlight .vg { color: #4ca !important; } /* Name.Variable.Global */
+.highlight .vi { color: #4ca !important; } /* Name.Variable.Instance */
+.highlight .il { color: #cd2828 !important; } /* Literal.Number.Integer.Long */

--- a/docs/_static/scss/general.scss
+++ b/docs/_static/scss/general.scss
@@ -139,17 +139,14 @@ h2 {
 .rst-content section ul {
     line-height: auto;
 }
-.rst-content section ul li {
-    list-style: none;
-}
-ul.simple li p {
-    line-height: 40px;
-}
 
 code,
 pre,
 pre span,
-span.pre {
+span.pre,
+.rst-content .linenodiv pre,
+.rst-content div[class^=highlight] pre,
+.rst-content pre.literal-block {
     font-family: 'Ubuntu Mono', monospace;
 }
 
@@ -157,7 +154,6 @@ ul.simple li code,
 code.docutils.literal.notranslate {
     border:none;
     width: max-content;
-    font-weight: 500;
     font-size: 13px;
     padding: 10px;
     margin: 10px 0;
@@ -183,7 +179,6 @@ code.docutils.literal.notranslate {
 
     .highlight {
         font-family: 'Ubuntu Mono', monospace;
-        font-weight: 500;
         font-size: 16px;
         padding: 10px;
         line-height: 24px;


### PR DESCRIPTION
This applies a 'Github Dark' theme to the code blocks as well. I don't think we're 100% there yet, but this looks way better imo.