### PR TITLE
docs: Improve magento2 Redis and Varnish docs

### DIFF
--- a/docs/ecommerce-applications/magento-2/how-to-configure-redis-for-magento-2.md
+++ b/docs/ecommerce-applications/magento-2/how-to-configure-redis-for-magento-2.md
@@ -16,71 +16,72 @@ Configure Redis Cache for Magento 2 Through the Commandline
 
 Use the following command to enable Redis backend caching:
 
-```nginx
-cd /data/web/magento2>bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=127.0.0.1 --cache-backend-redis-db=0>
+```console
+$ cd /data/web/magento2
+$ bin/magento setup:config:set \
+    --cache-backend=redis \
+    --cache-backend-redis-server=redismaster \
+    --cache-backend-redis-db=1
 ```
-Configure Redis Cache for Magento 2 by editing the env.php file
----------------------------------------------------------------
-
-To enable caching in Redis, extend your `/data/web/magento2/app/etc/env.php` with the following snippet. Add this in between the `cache` keys. (Without the `cache` key in the snippet)
-
-```php
-'cache' => array('frontend' => array( 'default' => array( 'backend' => 'Cm_Cache_Backend_Redis', 'backend_options' => array( 'server' => '127.0.0.1', 'port' => '6379', ), ), ),),
-```
-A complete env.php configuration example [can be found over here](https://gist.github.com/hn-support/4bf9575e7896abf57dff2b5ac15f05ef).
 
 Now flush your cache:
 
-```nginx
-rm -rf /data/web/magento2/var/cache/*
-redis-cli flushall
+```console
+$ rm -rf /data/web/magento2/var/cache/*
+$ redis-cli flushall
 ```
 Configure Redis Full Page Caching for Magento 2
 -----------------------------------------------
 
 To enable page caching Redis, extend your /data/web/magento2/app/etc/env.php with the following snippet. You should paste this in between the cache keys, so leave the cache tag in this snippet out of it.
 
-```php
- 'cache' => array ( 'frontend' => array ( 'default' => array ( 'backend' => 'Cm_Cache_Backend_Redis', 'backend_options' => array ( 'server' => '127.0.0.1', 'port' => '6379', ), ), // Start of snippet 'page_cache' => array ( 'backend' => 'Cm_Cache_Backend_Redis', 'backend_options' => array ( 'server' => '127.0.0.1', 'port' => '6379', 'database' => '1', 'compress_data' => '0', ), ), // End of snippet ), ),
+```console
+$ cd /data/web/magento2
+$ bin/magento setup:config:set \
+    --page-cache=redis \
+    --page-cache-redis-server=redismaster \
+    --page-cache-redis-db=2
 ```
-A complete env.php configuration example [can be found over here](https://gist.github.com/hn-support/4bf9575e7896abf57dff2b5ac15f05ef)
 
 And flush your cache:
 
-```bash
-rm -rf /data/web/magento2/var/cache/*
-redis-cli flushall
+```console
+$ rm -rf /data/web/magento2/var/cache/*
+$ redis-cli flushall
 ```
 Flush Your Caches
 -----------------
 
 To flush your Magento cache, clear the Redis database corresponding to your configured Redis database:
 
-```bash
-redis-cli -n $db flushdb
+```console
+$ redis-cli -n 1 flushdb
 ```
 Or alternatively use `n98-magerun2` or the Magento cli tool:
 
-```bash
+```console
 ## Flush using n98-magerun2
-n98-magerun2 cache:flush
+$ n98-magerun2 cache:flush
 ## Flush using magento cli
-cd /data/web/magento2 && php bin/magento cache:flush
+$ cd /data/web/magento2 && bin/magento cache:flush
 ```
 To flush all sessions, caches etc (flush the full Redis instance), use the following command:
 
-```nginx
-redis-cli flushall
+```console
+$ redis-cli flushall
 ```
 Changing the Compression Library
 --------------------------------
 
 It is possible to use the compression library 'Snappy' on Hypernode. More information about Snappy can be found in the changelog: [Release-4224](https://changelog.hypernode.com/changelog/release-4224/).
 
-In order to use the compression library Snappy for your Redis cache you need to add `'compression_library' => 'snappy',` in your env.php under:
+In order to use the compression library Snappy for your Redis cache you can run the following commands:
 
-```nginx
-'page_cache' => array ('backend' => 'Cm_Cache_Backend_Redis','backend_options' => array (
+```console
+$ bin/magento setup:config:set --cache-backend-redis-compression-lib=snappy
+
+# If you use Magento's builtin page cache with Redis
+$ bin/magento setup:config:set --page-cache-redis-compression-lib=snappy
 ```
 Configure Magento 2 to Use Redis as the Session Store
 -----------------------------------------------------
@@ -93,68 +94,57 @@ Hypernodes bigger than a Grow plan, often have enough memory to store the sessio
 
 As Magento 2 is fully supporting Redis, there is no need to install additional extensions to configure Redis. All you need to do is extend your `app/etc/env.php` and flush your cache.
 
-To enable session storage in Redis, extend your `/data/web/magento2/app/etc/env.php` with the following snippet:
+To enable session storage in Redis, run the following command:
 
-```nginx
-'session' => array(
-'save' => 'redis',
-'redis' => array(
-'host' => 'redismaster',
-'port' => '6379',
-'password' => '',
-'timeout' => '2.5',
-'persistent_identifier' => '',
-'database' => '2',
-'compression_threshold' => '2048',
-'compression_library' => 'gzip',
-'log_level' => '1',
-'max_concurrency' => '6',
-'break_after_frontend' => '5',
-'break_after_adminhtml' => '30',
-'first_lifetime' => '600',
-'bot_first_lifetime' => '60',
-'bot_lifetime' => '7200',
-'disable_locking' => '0',
-'min_lifetime' => '60',
-'max_lifetime' => '2592000',
-),
-),
+```console
+$ cd /data/web/magento2
+$ bin/magento setup:config:set \
+    --session-save=redis \
+    --session-save-redis-host=redismaster \
+    --session-save-redis-db=3
 ```
-A complete env.php configuration example [can be found over here](https://gist.github.com/hn-support/4bf9575e7896abf57dff2b5ac15f05ef)
 
 Now flush your cache:
 
-```nginx
-rm -rf /data/web/magento2/var/cache/*
-redis-cli flushall
+```console
+$ rm -rf /data/web/magento2/var/cache/*
+$ redis-cli flushall
 ```
 ### Enable Second Redis Instance for Sessions
 
-We have made is possible to enable a second Redis instance more tailored for saving session data (more informatie can be found in our [changelog](https://changelog.hypernode.com/changelog/experimental-changes-redis-sessions-aws-performance/))
+We have made is possible to enable a second Redis instance more tailored for saving session data (more information can be found in our [changelog](https://changelog.hypernode.com/changelog/experimental-changes-redis-sessions-aws-performance/)).
 
 To enable the second Redis instance for sessions you run the command: `hypernode-systemctl settings redis_persistent_instance --value True`
 
-After enabling the second Redis instance you need to update the `/data/web/public/app/etc/local.xml` file and change the port value to `6378` instead of the default `6379`. Furthermore you need to add the following line to your crontab:
+After enabling the second Redis instance you need to change the configured Redis session port value to `6378` instead of the default `6379` and the database to `0`, since we're using a separate Redis instance now:
+
+```console
+$ cd /data/web/magento2
+$ bin/magento setup:config:set \
+    --session-save-redis-port=6378 \
+    --session-save-redis-db=0
+```
+
+Furthermore you need to add the following line to your crontab:
 
 ```
 * * * * * redis-cli -p 6378 bgsave
 ```
+
 ### Test Whether Your Sessions Are Stored in Redis
 
 To verify whether your configuration is working properly, first clear your session store:
 
-```nginx
-rm /data/web/public/var/sessions/*
-
+```console
+$ rm /data/web/public/var/sessions/*
 ```
 
 Now open the site in your browser and hit `F5` a few times or log in to the admin panel. If all is well, no additional sessions files should be written to `/data/web/var/sessions`, but instead to the Redis database:
 
 To verify whether your configuration is working properly, first clear your session store:
 
-```nginx
-redis-cli -n 2 keys \*
-
+```console
+$ redis-cli -n 2 keys '*'
 ```
 Troubleshooting
 ---------------
@@ -167,8 +157,8 @@ In some cases we see that when Redis reaches the configured limit and tries to e
 
 A temporary solution is to flush the Redis cache, you can do this by using the `flushall` command:
 
-```nginx
-redis-cli flushall
+```console
+$ redis-cli flushall
 ```
 This will flush out all available Redis databases. Please keep in mind that this is only a temporary solution. The underlying cause is in the code of your application and needs to be permanently resolved.
 

--- a/docs/ecommerce-applications/magento-2/how-to-configure-varnish-for-magento-2-x.md
+++ b/docs/ecommerce-applications/magento-2/how-to-configure-varnish-for-magento-2-x.md
@@ -13,14 +13,20 @@ As Magento 2 supports Varnish out of the box, there is no need for the turpentin
 
 **First configure the Varnish version (4.0 or 6.0) via the [hypernode-systemctl tool](https://support.hypernode.com/knowledgebase/hypernode-systemctl-cli-tool/)**
 
-`hypernode-systemctl settings varnish_version 4.0`
+```console
+$ hypernode-systemctl settings varnish_version 4.0
+```
 
 **Or if you want to switch to Varnish 6.0**
-`hypernode-systemctl settings varnish_version 6.0`
+```console
+$ hypernode-systemctl settings varnish_version 6.0
+```
 
 **Enable Varnish via the [hypernode-systemctl tool](https://support.hypernode.com/knowledgebase/hypernode-systemctl-cli-tool/)**
 
-`hypernode-systemctl settings varnish_enabled true`
+```console
+$ hypernode-systemctl settings varnish_enabled true
+```
 
 **Enable Varnish via the [Service Panel](https://service.byte.nl/)**
 
@@ -29,7 +35,7 @@ As Magento 2 supports Varnish out of the box, there is no need for the turpentin
 * Click on "Varnish"
 * Use the switch to enable Varnish
 
-**Enable Varnish via the[Control Panel](https://auth.hypernode.com/)**
+**Enable Varnish via the [Control Panel](https://auth.hypernode.com/)**
 
 * Click on "Hypernodes"
 * Click on "Caching"
@@ -41,7 +47,9 @@ Configure Varnish on the Vhost
 
 Since the introduction of **[hypernode-manage-vhosts](https://changelog.hypernode.com/changelog/release-7166-hypernode-manage-vhosts-enabled-by-default/)**Hypernode may work somewhat different than you might be used to. With HMV enabled, it requires one more step to configure Varnish for your shop/vhost. Remember, for each domain, there should be a vhost created. You can list an overview of all configured vhosts with `hypernode-manage-vhosts --list`. While you do that, note that there is a column, "varnish". By default this is set to "False". Which means that Varnish isn't configured for this vhost. You can configure Varnish for the vhost by running the following command:
 
-`hypernode-manage-vhosts EXAMPLE.COM --varnish`
+```console
+$ hypernode-manage-vhosts EXAMPLE.COM --varnish
+```
 
 Configure Magento 2.x for Varnish
 ---------------------------------
@@ -58,38 +66,36 @@ Configure Magento 2.x for Varnish
 
 ### Configure Your Backend Servers Through the Commandline
 
-If you want to flush the Varnish cache from the Magento backend, you need to add the Varnish server in your Magento config to `http-cache-hosts`
-
-.
+If you want to flush the Varnish cache from the Magento backend, you need to add the Varnish server in your Magento config to `http-cache-hosts`.
 
 To do this, run the following command:
 
-```bash
-cd /data/web/magento2;
-chmod 750 bin/magento;
-bin/magento setup:config:set --http-cache-hosts=127.0.0.1:6081;
-
+```console
+$ cd /data/web/magento2;
+$ chmod 750 bin/magento;
+$ bin/magento setup:config:set --http-cache-hosts=127.0.0.1:6081;
 ```
+
 Now when you flush your caches in cache management, your varnish full_page cache will be flushed too.
 
 ### Test and Upload Your VCL
 
 After downloading your VCL, check (in notepad or something similar) if the following configuration is present:
 
-```php
+```vcl
 backend default {
   .host = "127.0.0.1";
   .port = "8080";
 }
-
 ```
+
 If your VCL checks out, upload it to your Hypernode (using SCP, FTP or FTPS or whichever client you prefer)
 
 #### Remove Health Check Probe from Configuration
 
 **Note:** The default VCL might have the following configuration:
 
-```php
+```vcl
 backend default {
      .host = "localhost";
      .port = "8080";
@@ -102,8 +108,8 @@ backend default {
          .threshold = 5;
     }
 }
-
 ```
+
 Make sure you change this to the aforementioned configuration (without the health_check probe), since this will break on our Nginx configuration and will therefore result in a `503 Guru Meditation` error.
 
 Import Your VCL into the Varnish Daemon
@@ -111,16 +117,16 @@ Import Your VCL into the Varnish Daemon
 
 Import your VCL into Varnish and save as `mag2`:
 
-```bash
-varnishadm vcl.load mag2 /data/web/default.vcl
+```console
+$ varnishadm vcl.load mag2 /data/web/default.vcl
 
 ```
 The output should say: *your VCL is compiled*. If you receive a `Permission denied` error, and have recently activated Varnish, please close all ssh sessions, and log back in to reload your new permissions.
 
 Now tell Varnish to activate the loaded VCL:
 
-```bash
-varnishadm vcl.use mag2
+```console
+$ varnishadm vcl.use mag2
 
 ```
 In the examples we used the name ‘mag2’ for our VCL, but you can use any name you prefer.
@@ -129,9 +135,8 @@ In the examples we used the name ‘mag2’ for our VCL, but you can use any nam
 
 List all VCL’s with the following command:
 
-```bash
-varnishadm vcl.list
-
+```console
+$ varnishadm vcl.list
 ```
 The VCL you just imported and activated should have the status `active`. If all went well, varnish is now functioning with a working VCL.
 
@@ -148,15 +153,13 @@ To flush the Varnish cache of your Magento store on the command line you can use
 
 Additionally you can flush your cache through the Magento admin backend or use `varnishadm` directly:
 
-```bash
-varnishadm "ban req.url ~ ."
-
+```console
+$ varnishadm "ban req.url ~ ."
 ```
 Or if you want to flush the cache for a single domain in a multisite setup:
 
-```bash
-varnishadm "ban req.http.host == example.com"
-
+```console
+$ varnishadm "ban req.http.host == example.com"
 ```
 Warming Your Cache
 ------------------
@@ -168,17 +171,18 @@ Enable Debug Headers
 
 If you are implementing Varnish on Magento 2, you might want to view some caching headers that indicate whether the page is cacheable or not. To do this, put your Magento install in `Developer mode`. Now if you request a page through curl, you can see the `X-Magento-Cache-Debug` header:
 
-```bash
-curl -I -v --location-trusted 'example.hypernode.io' > /dev/null | grep X-Magento
-
+```console
+$ curl -I -v --location-trusted 'example.hypernode.io' > /dev/null | grep X-Magento
 ```
+
 Which will show the debug headers:
 
-```bash
+```console
+$ curl -I -v --location-trusted 'example.hypernode.io' > /dev/null | grep X-Magento
 X-Magento-Cache-Control: max-age=86400, public, s-maxage=86400
 X-Magento-Cache-Debug: MISS
-
 ```
+
 VCL Tip
 -------
 
@@ -189,8 +193,8 @@ In our experience the by default generated .vcl from your Magento backend often 
 Troubleshooting
 ---------------
 
-* If you are receiving `Permission denied` errors while running `varnishadm` or other Varnish CLI commands, and you have just activated Varnish, close any existing ssh sessions, and log back in to reload your updated permissions.
-* If your Varnish setup is not working over SSL, check [this article](https://support.hypernode.com/en/hypernode/ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-byte-nl#Redirecting-to-HTTPS-When-Using-Varnish)
+- If you are receiving `Permission denied` errors while running `varnishadm` or other Varnish CLI commands, and you have just activated Varnish, close any existing ssh sessions, and log back in to reload your updated permissions.
+- If your Varnish setup is not working over SSL, check [this article](https://support.hypernode.com/en/hypernode/ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-byte-nl#Redirecting-to-HTTPS-When-Using-Varnish)
 
 ### 502 Errors
 
@@ -200,13 +204,12 @@ Sometimes while you enable Varnish, or even while Varnish was already enabled an
 
 This error can 9 out of 10 times be fixed by adding some Nginx config. You can create a file, i.e. **~/nginx/server.header_buffer** with the following content:
 
-```bash
+```nginx
 fastcgi_buffers 16 16k;
 fastcgi_buffer_size 32k;
 proxy_buffer_size 128k;
 proxy_buffers 4 256k;
 proxy_busy_buffers_size 256k;
-
 ```
 
 ### 503 Errors
@@ -218,7 +221,6 @@ proxy_busy_buffers_size 256k;
 
 If you ever need to restart Varnish you can use the following systemctl command for that:
 
-```bash
-hypernode-servicectl restart varnish
-
+```console
+$ hypernode-servicectl restart varnish
 ```


### PR DESCRIPTION
This is mainly done by setting the right code block syntax and getting rid of legacy stuff. Looks way better now