### PR TITLE
ci: Use GITHUB_HEAD_REF instead of GITHUB_REF

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -104,6 +104,6 @@ $dockerStage->addServer($DOCKER_HOST);
 
 $testingStage = $configuration->addStage("acceptance", "docs");
 $testingStage->addBrancherServer("hntestgroot")
-    ->setLabels(['stage=acceptance', 'ci_ref=' . (\getenv('GITHUB_REF') ?: 'none')]);
+    ->setLabels(['stage=acceptance', 'ci_ref=' . (\getenv('GITHUB_HEAD_REF') ?: 'none')]);
 
 return $configuration;


### PR DESCRIPTION
The `GITHUB_REF` env is not the same when a PR is opened and when it's merged. The `GITHUB_HEAD_REF` env contains the source branch name in all pull_request event types