### PR TITLE
Deploy nginx redirects

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,6 @@ jobs:
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - run: apt update && apt install -y python3 virtualenv
       - run: hypernode-deploy build -vvv
       - name: archive production artifacts
         uses: actions/upload-artifact@v3

--- a/bin/generate_nginx_redirects
+++ b/bin/generate_nginx_redirects
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from hypernode.redirect.generate_nginx_redirects import main
+
+if __name__ == "__main__":
+    main()

--- a/hypernode/redirect/generate_nginx_redirects.py
+++ b/hypernode/redirect/generate_nginx_redirects.py
@@ -1,0 +1,31 @@
+import os.path
+from pathlib import Path
+from typing import List
+
+from frontmatter import Frontmatter
+
+from hypernode.common.docs import get_all_docs
+from hypernode.common.settings import DOCS_DIR
+
+
+def get_redirects_from_doc(doc: Path) -> List[str]:
+    fm = Frontmatter.read_file(doc)
+    attributes = fm["attributes"] or {}
+    return attributes.get("redirect_from", [])
+
+
+def get_path_for_doc(doc: Path) -> str:
+    relative_path = Path(os.path.relpath(doc, DOCS_DIR))
+    path = "/{}/{}".format(
+        relative_path.parent, relative_path.name.replace(".md", ".html")
+    )
+    path = path.replace("/./", "/")
+    path = path.replace("/index.html", "/")
+    return path
+
+
+def main():
+    for doc in get_all_docs():
+        for redirect in get_redirects_from_doc(doc):
+            doc_path = get_path_for_doc(doc)
+            print("rewrite ^{}$ {} permanent;".format(redirect, doc_path))


### PR DESCRIPTION
I also played around with the `deploy.php` for a bit. A few improvements:
- hmv for whatever hostname now only happens for `acceptance`
- hmv for docs.hypernode.io (and later docs.hypernode.com) only happens for `production`
- The deploy excludes weren't effective, now they should be.

With the acceptance/production tasks I found a bug that caused both tasks to always run, this is fixed with https://github.com/ByteInternet/hypernode-deploy/pull/79.