### PR TITLE
docs: Set html_baseurl

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,10 @@ jobs:
       - uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Set env for production build
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "DOCS_BASE_URL=docs.hypernode.io" >> $GITHUB_ENV
       - run: hypernode-deploy build -vvv
       - name: archive production artifacts
         uses: actions/upload-artifact@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+import os
 
 # -- Path setup --------------------------------------------------------------
 
@@ -71,6 +72,8 @@ html_context = {
 }
 html_show_sphinx = False
 html_show_sourcelink = False
+if os.getenv("DOCS_BASE_URL"):
+    html_baseurl = os.getenv("DOCS_BASE_URL")
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
This will cause the `canonical` tag to be added tot the head, which is very important for SEO.

The DOCS_BASE_URL setting in CI is a bit awkward, but I'm not so sure what the right way to do this would be.