### PR TITLE
docs: Improve results for small search queries

### DIFF
--- a/docs/_static/searchtools.js
+++ b/docs/_static/searchtools.js
@@ -282,7 +282,7 @@ const Search = {
 
     const queryLower = query.toLowerCase();
     for (const [title, foundTitles] of Object.entries(allTitles)) {
-      if (title.toLowerCase().includes(queryLower) && (queryLower.length >= title.length/2)) {
+      if (title.toLowerCase().includes(queryLower)) {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
           results.push([


### PR DESCRIPTION
The search implementation didn't take search matches into account if the search query was smaller than title length: `queryLower.length >= title.length/2`. See 162f9b17166bbe34a7c049fda6ee1b0fc8ee62a7