### PR TITLE
fix dead link nodejs install in yarn instructions

### DIFF
--- a/docs/hypernode-platform/tools/how-to-use-node-js-and-npm-on-hypernode.md
+++ b/docs/hypernode-platform/tools/how-to-use-node-js-and-npm-on-hypernode.md
@@ -22,7 +22,7 @@ If you use the installed version, you can just start using node and npm.
 
 By default, the installed NodeJS version on our Hypernode platform is v10. You can check this on your Hypernode by running the command `node -v`. If you need to manually upgrade an app to another Node.js version like 18, you can use the command below:
 
-```nginx
+```bash
 hypernode-systemctl settings nodejs_version 18
 ```
 
@@ -34,15 +34,15 @@ If you want to execute the tools that you installed using `npm`, you should make
 
 This PATH variable is used by the Bash shell to locate binaries and scripts. You can adjust it by exporting the PATH variable:
 
-```nginx
- export PATH="/data/web/node_modules/.bin:$PATH"
+```bash
+export PATH="/data/web/node_modules/.bin:$PATH"
 ```
 
 If you want this setting to be configured every time you log in to your Hypernode, you can add this setting to your `~/.profile`, this file is loaded every time a new shell is spawned.
 
 To configure your PATH variable at login time, run the following command:
 
-```nginx
+```bash
 echo 'export PATH="/data/web/node_modules/.bin:$PATH"' >> ~/.profile
 ```
 
@@ -52,61 +52,61 @@ Now every time you log in, the Bash shell is configured to look for tools in `/d
 
 Let's install some packages.
 
-When your `PATH` is setup correctly, after the installation with `npm install`, you should immediately be able to use the newly installed tool.
+When your `PATH` is set up correctly, after the installation with `npm install`, you should immediately be able to use the newly installed tool.
 
 To find the latest command line tool installed, run: `ls -ltr /data/web/node_modules/.bin | tail -1`
 
 ### Install Gulp
 
-```nginx
- npm install gulp gulp-cli
+```bash
+npm install gulp gulp-cli
 ```
 
 ### Install Grunt
 
-```nginx
+```bash
 npm install grunt grunt-cli
 ```
 
 ### Install Sass
 
-```nginx
+```bash
 npm install sass
 ```
 
 ### Install Compass
 
-```nginx
- npm install compass
+```bash
+npm install compass
 ```
 
 When your Hypernode is using the OS [Debian Buster](https://changelog.hypernode.com/changelog/release-7351-new-hypernodes-will-be-booted-on-debian-buster/) then the aforementioned method will not be applicable. Instead you can use the following command to install compass
 
-```nginx
+```bash
 gem install --user-install compass
 ```
 
 Next you need to set the correct path so you don't have to type the absolute path to access compass each time. You can do s with the command:
 
-```nginx
+```bash
 export PATH="/data/web/.gem/ruby/2.5.0/gems/compass-1.0.3/bin:$PATH"
 ```
 
 ### Install Less
 
-```nginx
+```bash
 npm install less
 ```
 
 ### Install Yarn
 
-*To install yarn, a more recent version of nodejs is required, so [follow the instructions and download and unpack a newer version of nodejs](how-to-use-node-js-and-npm-on-hypernode.md#using-an-newer-version-of-node-js) first.*
+*To install yarn, a more recent version of nodejs is required, so [follow the instructions and download and unpack a newer version of nodejs](#using-a-newer-version-of-nodejs) first.*
 
-```nginx
+```bash
 npm install yarn
 ```
 
-## **Using an newer version of Node.js**
+## **Using a newer version of Node.js**
 
 ### **Install a newer version of Node.js**
 
@@ -118,20 +118,17 @@ All we need to do is download and unpack them to make use of node and npm and in
 In this example we use version v14.17.6 but the installation process is the same when using older or newer versions.
 
 - First, create the directory where we will unpack Node.js:
-
-```nginx
-mkdir /data/web/.node
-```
-
+  ```bash
+  mkdir /data/web/.node
+  ```
 - Then, get the precompiled package from the Node.js website and unpack it in our directory:
+  ```bash
+  wget https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz -O /tmp/node.txz
+  cd ~/.node && tar xvfJ /tmp/node.txz -C . --strip-components=1
+  rm /tmp/node.txz
+  ```
 
-```nginx
-wget [https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-x64.tar.xz](https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x64.tar.xz) -O /tmp/node.txz
-cd ~/.node && tar xvfJ /tmp/node.txz -C . --strip-components=1
-rm /tmp/node.txz
-```
-
-That’s it, you now have a precompiled node installation in `~/node`
+That’s it, you now have a precompiled node installation in `~/node`.
 
 ### Configure a Manually Installed Node.js
 
@@ -139,18 +136,18 @@ To run the manually installed executables, you need to change your `PATH` variab
 
 To do this, run the following command to add the locations to your PATH:
 
-```nginx
- export PATH="/data/web/node_modules/.bin:/data/web/.node/bin:$PATH"
+```bash
+export PATH="/data/web/node_modules/.bin:/data/web/.node/bin:$PATH"
 ```
 
 Or to make the settings permanent, add it to your `~/.profile`:
 
-```nginx
- echo 'export PATH="/data/web/node_modules/.bin:/data/web/.node/bin:$PATH"' >> ~/.profile
+```bash
+echo 'export PATH="/data/web/node_modules/.bin:/data/web/.node/bin:$PATH"' >> ~/.profile
 ```
 
 Both the installations (the already installed or the precompiled self-downloaded version) use `/data/web/node_modules` as their location to install new packages to when using npm.
 
 ## Troubleshooting
 
-- When using npm search, so much memory is used that on Hypernode Grow plans, your shell will get killed and you’ll be automagically logged out of your Hypernode due to our out of memory protection.
+- When using npm search, so much memory is used that on Hypernode Grow plans, your shell will get killed, and you’ll be automagically logged out of your Hypernode due to our out of memory protection.


### PR DESCRIPTION
currently points to https://archive.support.hypernode.com/knowledgebase/use-nodejs-npm-hypernode/#Using_a_newer_version_of_NodeJs which is a dead link

not sure if linking to the absolute url is the way to go here or if I should link to the .md file? would that work with `#Using_a_newer_version_of_NodeJs`?