### PR TITLE
Set theme-color to Hypernode primary color

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -19,6 +19,7 @@
   <meta charset="utf-8" />
   {{- metatags }}
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#063b67" />
   {%- block htmltitle %}
   <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
   {%- endblock -%}


### PR DESCRIPTION
On mobile devices, the [theme-color meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) makes the browser take on the specified theme color for certain elements (like the url bar etc).

Primary color was sourced from `docs/_static/scss/colors.scss`.