### PR TITLE
ci: Set production deploy concurrency

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -73,6 +73,7 @@ jobs:
   deploy_production:
     needs: build
     runs-on: ubuntu-latest
+    concurrency: production
     environment:
       name: production
       url: https://docs.hypernode.io


### PR DESCRIPTION
When merging multiple branches to master, multiple deploy workflows start, but only one deploy may happen at a time. With this, deploy_production jobs will be pending if another deploy_production job is already running.