### PR TITLE
pre-depend on the man-db package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,4 +10,5 @@ Package: hndocsnext
 Section: doc
 Architecture: all
 Depends: ${misc:Depends}
+Pre-Depends: man-db
 Description: Hypernode docs in manpage form. Run 'man hypernode'.


### PR DESCRIPTION
to prevent:
```
"mandb: can't open the manpath configuration file /etc/manpath.config", "dpkg: error processing package hndocsnext (--configure)
```