### PR TITLE
add git to build deps for manpage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: hndocsnext
 Priority: optional
 Maintainer: Hypernode Tech Team <support@hypernode.com>
-Build-Depends: debhelper (>= 9), python3, python3-venv, python3-dev
+Build-Depends: debhelper (>= 9), python3, python3-venv, python3-dev, git
 Standards-Version: 3.9.4
 Homepage: https://github.com/ByteInternet/hypernode-docs-next
 Vcs-Git: git@github.com:ByteInternet/hypernode-docs-next.git


### PR DESCRIPTION
to fix:
```
  Running setup.py install for MarkupSafe: started
    Running setup.py install for MarkupSafe: finished with status 'done'
  Running setup.py install for pyyaml: started
    Running setup.py install for pyyaml: finished with status 'done'
  Running setup.py install for ruamel.yaml.clib: started
    Running setup.py install for ruamel.yaml.clib: finished with status 'done'
  Running setup.py install for inotify: started
    Running setup.py install for inotify: finished with status 'done'
Successfully installed GitPython-3.1.30 Jinja2-3.1.2 MarkupSafe-2.1.2 Pygments-2.14.0 alabaster-0.7.13 attrs-22.2.0 babel-2.11.0 backcall-0.2.0 beautifulsoup4-4.11.1 black-22.10.0 certifi-2022.12.7 cfgv-3.3.1 charset-normalizer-3.0.1 click-8.1.3 decorator-5.1.1 distlib-0.3.6 docutils-0.19 execnet-1.9.0 filelock-3.9.0 flake8-3.9.2 frontmatter-3.0.7 gitdb-4.0.10 identify-2.5.15 idna-3.4 imagesize-1.4.1 importlib-metadata-6.0.0 iniconfig-2.0.0 inotify-0.2.10 ipython-7.32.0 jedi-0.18.2 markdown-it-py-2.1.0 markdownify-0.11.2 matplotlib-inline-0.1.6 mccabe-0.6.1 mdformat-0.7.16 mdformat-frontmatter-0.4.1 mdformat-myst-0.1.5 mdformat-tables-0.4.1 mdit-py-plugins-0.3.3 mdurl-0.1.2 mypy-0.950 mypy-extensions-0.4.3 myst-parser-0.18.1 nodeenv-1.7.0 nose-1.3.7 packaging-23.0 parso-0.8.3 pathspec-0.10.3 pexpect-4.8.0 pickleshare-0.7.5 platformdirs-2.6.2 pluggy-1.0.0 pre-commit-2.18.1 prompt-toolkit-3.0.36 ptyprocess-0.7.0 py-1.11.0 pycodestyle-2.7.0 pyflakes-2.3.1 pytest-7.1.2 pytest-forked-1.4.0 pytest-xdist-2.5.0 python-slugify-6.1.2 pytz-2022.7.1 pyyaml-5.1 requests-2.28.2 ruamel.yaml-0.17.21 ruamel.yaml.clib-0.2.7 six-1.16.0 smmap-5.0.0 snowballstemmer-2.2.0 soupsieve-2.3.2.post1 sphinx-5.3.0 sphinx-copybutton-0.5.1 sphinx-notfound-page-0.8.3 sphinx-rtd-theme-1.1.1 sphinx-sitemap-2.4.0 sphinxcontrib-applehelp-1.0.2 sphinxcontrib-devhelp-1.0.2 sphinxcontrib-htmlhelp-2.0.0 sphinxcontrib-jsmath-1.0.1 sphinxcontrib-mermaid-0.7.1 sphinxcontrib-qthelp-1.0.3 sphinxcontrib-serializinghtml-1.1.5 text-unidecode-1.3 toml-0.10.2 tomli-2.0.1 tox-3.25.0 traitlets-5.8.1 typed-ast-1.5.4 typing-extensions-4.4.0 urllib3-1.26.14 virtualenv-20.17.1 wcwidth-0.2.6 zipp-3.11.0
bash -c 'source venv/bin/activate; bin/build_manpage'
/build/hndocsnext-20230121.173551/docs /build/hndocsnext-20230121.173551
make[1]: Entering directory '/build/hndocsnext-20230121.173551/docs'
Running Sphinx v5.3.0

Extension error:
Could not import extension hypernode.sphinx.extensions.updated_at (exception: Failed to initialize: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.

This initial warning can be silenced or aggravated in the future by setting the
$GIT_PYTHON_REFRESH environment variable. Use one of the following values:
    - quiet|q|silence|s|none|n|0: for no warning or exception
    - warn|w|warning|1: for a printed warning
    - error|e|raise|r|2: for a raised exception

Example:
    export GIT_PYTHON_REFRESH=quiet
)
make[1]: *** [Makefile:20: man] Error 2
make[1]: Leaving directory '/build/hndocsnext-20230121.173551/docs'
make: *** [debian/rules:11: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```