### PR TITLE
pip install wheel in debian packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@
 
 build:
 	python3 -m venv venv
+	venv/bin/pip install wheel
 	venv/bin/pip install -r requirements/development.txt
 	bash -c 'source venv/bin/activate; bin/build_manpage'
 	mv docs/_build/man/docs.1 docs/_build/man/hypernode.3


### PR DESCRIPTION
to prevent this error during the pip install:
```
Building wheels for collected packages: pyyaml, inotify, MarkupSafe, ruamel.yaml.clib
  Running setup.py bdist_wheel for pyyaml: started
  Running setup.py bdist_wheel for pyyaml: finished with status 'error'
  Complete output from command /build/hndocsnext-20230124.142001/venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-88vipxf9/pyyaml/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-65xlmawf --python-tag cp37:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'
```