### PR TITLE
update isort to fix poetry config invalid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     -   id: autoflake
         args: ["--in-place", "--remove-unused-variables", "--remove-all-unused-imports"]
 -   repo: https://github.com/pycqa/isort
-    rev: '5.11.4'
+    rev: '5.11.5'
     hooks:
     -   id: isort
         name: isort (python)


### PR DESCRIPTION
fixes:
```
  An unexpected error has occurred: CalledProcessError: command: ('/home/runner/.cache/pre-commit/repodus38792/py_env-python3.9/bin/python', '-mpip', 'install', '.')
  return code: 1
  expected return code: 0
  stdout:
      Processing /home/runner/.cache/pre-commit/repodus38792
        Installing build dependencies: started
        Installing build dependencies: finished with status 'done'
        Getting requirements to build wheel: started
        Getting requirements to build wheel: finished with status 'done'
        Preparing metadata (pyproject.toml): started
        Preparing metadata (pyproject.toml): finished with status 'error'

  stderr:
        error: subprocess-exited-with-error

        × Preparing metadata (pyproject.toml) did not run successfully.
        │ exit code: 1
        ╰─> [14 lines of output]
            Traceback (most recent call last):
              File "/home/runner/.cache/pre-commit/repodus38792/py_env-python3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
                main()
              File "/home/runner/.cache/pre-commit/repodus38792/py_env-python3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
                json_out['return_val'] = hook(**hook_input['kwargs'])
              File "/home/runner/.cache/pre-commit/repodus38792/py_env-python3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 152, in prepare_metadata_for_build_wheel
                return hook(metadata_directory, config_settings)
              File "/tmp/pip-build-env-rpi25_l2/overlay/lib/python3.9/site-packages/poetry/core/masonry/api.py", line 40, in prepare_metadata_for_build_wheel
                poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
              File "/tmp/pip-build-env-rpi25_l2/overlay/lib/python3.9/site-packages/poetry/core/factory.py", line 57, in create_poetry
                raise RuntimeError("The Poetry configuration is invalid:\n" + message)
            RuntimeError: The Poetry configuration is invalid:
              - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

also see https://github.com/PyCQA/isort/releases/tag/5.11.5