### PR TITLE
ci: Set build artifact retention

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           name: deployment-build
           path: build/build.tgz
+          retention-days: 5
 
   deploy_acceptance:
     needs: build


### PR DESCRIPTION
The default retention for a build artifact is 90 days, that's way longer than we need.