### PR TITLE
Update how-to-configure-redis-for-magento-2.md

### DIFF
--- a/docs/ecommerce-applications/magento-2/how-to-configure-redis-for-magento-2.md
+++ b/docs/ecommerce-applications/magento-2/how-to-configure-redis-for-magento-2.md
@@ -127,7 +127,7 @@ $ redis-cli flushall
 
 We have made is possible to enable a second Redis instance more tailored for saving session data (more information can be found in our [changelog](https://changelog.hypernode.com/changelog/experimental-changes-redis-sessions-aws-performance/)).
 
-To enable the second Redis instance for sessions you run the command: `hypernode-systemctl settings redis_persistent_instance --value True`
+To enable the second Redis instance for sessions you run the command: `hypernode-systemctl settings redis_persistent_instance True`
 
 After enabling the second Redis instance you need to change the configured Redis session port value to `6378` instead of the default `6379` and the database to `0`, since we're using a separate Redis instance now:
 


### PR DESCRIPTION
The --value option has been deprecated. Please use hypernode-systemctl settings <attribute> <value> instead.