### PR TITLE
Update path were to set sitemap magento 2

### DIFF
--- a/docs/ecommerce-applications/magento-2/how-to-create-a-sitemap-xml-for-magento-2-x.md
+++ b/docs/ecommerce-applications/magento-2/how-to-create-a-sitemap-xml-for-magento-2-x.md
@@ -51,7 +51,7 @@ Let’s start with defining a `sitemap.xml` for your webshop:
 Now fill in the required information:
 
 - Filename: `sitemap.xml`
-- Path: `/sitemaps/`
+- Path: `/pub/sitemaps/`
 - In case you have multiple store views, select the corresponding store view
 - Select `Save & Generate`
 


### PR DESCRIPTION
The current docs: Path: /sitemaps/ but this will not work because magento2 starts /data/web/magento2.  This way, the sitemap can't be saved because the sitemap directory is made here /data/web/magento2/pub/sitemaps.

The correct Path to save the sitemap to is /pub/sitemaps/.