### PR TITLE
ci: Set environment for cleanup action

### DIFF
--- a/.github/workflows/cleanup_acceptance.yaml
+++ b/.github/workflows/cleanup_acceptance.yaml
@@ -8,6 +8,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     container: quay.io/hypernode/deploy:3-php8.1-node18
+    environment: acceptance
     steps:
       - uses: actions/checkout@v2
       - name: Dump env


### PR DESCRIPTION
`HYPERNDOE_API_TOKEN` is only set for the acceptance environment, that's why the cleanup_acceptance job was failing