### PR TITLE
docs/static: Change pygments block prompt color

### DIFF
--- a/docs/_static/pygments.css
+++ b/docs/_static/pygments.css
@@ -20,7 +20,7 @@
 .highlight .gh { color: #ffffff !important; } /* Generic.Heading */
 .highlight .gi { color: #589819 !important; } /* Generic.Inserted */
 .highlight .go { color: #cccccc !important; } /* Generic.Output */
-.highlight .gp { color: #aaaaaa !important; } /* Generic.Prompt */
+.highlight .gp { color: #80da10 !important; } /* Generic.Prompt */
 .highlight .gs { color: #d0d0d0 !important; } /* Generic.Strong */
 .highlight .gu { color: #ffffff !important; } /* Generic.Subheading */
 .highlight .gt { color: #d22323 !important; } /* Generic.Traceback */


### PR DESCRIPTION
The prompt of a console snippet should be more distinctive for readability purposes.