### PR TITLE
Copy docs from community docs

### DIFF
--- a/docs/best-practices/testing/how-to-use-hypernode-docker.md
+++ b/docs/best-practices/testing/how-to-use-hypernode-docker.md
@@ -1,13 +1,12 @@
 ---
 myst:
   html_meta:
-    description: 'Docker image can be used to set up a fast and easy local development environment for Hypernode.
- See intstructions that guide you through the process. '
+    description: 'Docker image can be used to set up a fast and easy local development
+      environment for Hypernode. See intstructions that guide you through the process. '
     title: How to use hypernode docker?
 redirect_from:
   - /en/hypernode/hypernode-docker/how-to-use-hypernode-docker/
 ---
-
 
 # Usage of hypernode-docker
 
@@ -26,6 +25,7 @@ We have tested usage of the Hypernode Docker image on Apple silicon ourselves an
 ### The Debian Buster hypernode-docker
 
 Starting the container
+
 ```
 docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker:latest
 docker run docker.hypernode.com/byteinternet/hypernode-buster-docker:latest
@@ -34,6 +34,7 @@ docker run docker.hypernode.com/byteinternet/hypernode-buster-docker:latest
 Now with the introduction of Debian Buster we have also made it so that for some of the possible configurations we have provided a pre-built image so it is not necessary anymore to [manually install a different MySQL](https://github.com/ByteInternet/hypernode-docker/issues/33) for example than what would be in the default box.
 
 These are the URLs of the containers with specific configurations:
+
 ```
 docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php56-mysql56:latest
 docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php70-mysql56:latest
@@ -66,6 +67,7 @@ docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php82-mysq
 ### Logging into the container
 
 Get the IP address
+
 ```bash
 # Find the container ID
 docker ps
@@ -74,6 +76,7 @@ docker inspect -f '{{ .NetworkSettings.IPAddress }}' <the container ID>
 ```
 
 Log in to the container:
+
 ```bash
 # SSH into the machine using the retrieved IP address. Example:
 ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null app@172.17.0.2
@@ -96,6 +99,7 @@ bash /etc/my_init.d/60_restart_services.sh
 If you only want to restart a specific service, inspect the `restart_services.sh` script and kill the screen for the service you want to restart. Then run the corresponding screen command to start the service again.
 
 ## See our excellent Documentation!
+
 <!--
 [Starting the container](Documentation/starting-the-container.md)
 

--- a/docs/best-practices/testing/how-to-use-hypernode-docker.md
+++ b/docs/best-practices/testing/how-to-use-hypernode-docker.md
@@ -1,0 +1,141 @@
+---
+myst:
+  html_meta:
+    description: 'Docker image can be used to set up a fast and easy local development environment for Hypernode.
+ See intstructions that guide you through the process. '
+    title: How to use hypernode docker?
+redirect_from:
+  - /en/hypernode/hypernode-docker/how-to-use-hypernode-docker/
+---
+
+
+# Usage of hypernode-docker
+
+The official [Hypernode](http://hypernode.com/) Docker image for Magento development. This image can be used to set up a fast and easy local development environment for Hypernode, or as a build machine in a CI environment representative of the production environment. The image contains the exact same packages and configuration as a real Hypernode except for some Docker specific tweaks. By testing and developing against this image you can be sure that when you deploy to a Hypernode in production there will be no surprises because of different software versions or configurations.
+
+We build this image multiple times a day (every time we do a [release](https://support.hypernode.com/category/changelog/)) by applying our configuration management on the [phusion/baseimage-docker](https://github.com/phusion/baseimage-docker) ['fat' container](https://blog.phusion.nl/2015/01/20/baseimage-docker-fat-containers-treating-containers-vms/). By treating the Docker as a lightweight VM instead of as a vehicle for a single process we stay close to what an actual Hypernode actually looks like. No micro-services or a multi-container application, but a single instance with minimal network overhead and all batteries included.
+
+The `hypernode-docker` image has SSH, PHP, NGINX, MySQL, Redis and Varnish. The biggest difference between a real Hypernode and this container is that this environment does not have an [init system](https://en.wikipedia.org/wiki/Init). While it is possible to [run systemd within a Docker Container](https://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/) if the host is also runs [systemd](https://www.freedesktop.org/wiki/Software/systemd/), we choose not to do so to achieve greater compatibility and user-friendliness.
+
+## Usage
+
+**Note about performance**
+
+We have tested usage of the Hypernode Docker image on Apple silicon ourselves and have found while it works out of the box, performance is unfortunately suboptimal (our current measures show 35 seconds of load time for a stock Magento homepage). If this performance drawback is fine for you, go ahead with it. If you need more performance when using the Hypernode Docker image, we recommend running the Docker image on a system that can run the image natively, like a workstation/laptop with an Intel or AMD processor. You could even run these images on a server with an AMD/Intel processor. And manage the test environments remotely through SSH, SFTP along with tools like VSCode.
+
+### The Debian Buster hypernode-docker
+
+Starting the container
+```
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker:latest
+docker run docker.hypernode.com/byteinternet/hypernode-buster-docker:latest
+```
+
+Now with the introduction of Debian Buster we have also made it so that for some of the possible configurations we have provided a pre-built image so it is not necessary anymore to [manually install a different MySQL](https://github.com/ByteInternet/hypernode-docker/issues/33) for example than what would be in the default box.
+
+These are the URLs of the containers with specific configurations:
+```
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php56-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php70-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php71-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php72-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php73-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php74-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php80-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php81-mysql56:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php56-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php70-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php71-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php72-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php73-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php74-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php80-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php81-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php82-mysql57:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php56-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php70-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php71-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php72-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php73-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php74-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php80-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php81-mysql80:latest
+docker pull docker.hypernode.com/byteinternet/hypernode-buster-docker-php82-mysql80:latest
+```
+
+### Logging into the container
+
+Get the IP address
+```bash
+# Find the container ID
+docker ps
+# Find the IP address of the container
+docker inspect -f '{{ .NetworkSettings.IPAddress }}' <the container ID>
+```
+
+Log in to the container:
+```bash
+# SSH into the machine using the retrieved IP address. Example:
+ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null app@172.17.0.2
+# Or as the root user
+ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null root@172.17.0.2
+```
+
+<!-- The password is `insecure_docker_ssh_password`, or use the [pregenerated key](keys/README.md). -->
+
+### Restarting services
+
+Because `systemctl` is not available inside the container, the services are started by an [init script](https://github.com/phusion/baseimage-docker#running-scripts-during-container-startup) on container startup. Note that because the systemd unit files are not parsed there could be a slight drift between what commandline flags the processes actually use in production compared to in this contanier.
+
+To restart all services run:
+
+```bash
+bash /etc/my_init.d/60_restart_services.sh
+```
+
+If you only want to restart a specific service, inspect the `restart_services.sh` script and kill the screen for the service you want to restart. Then run the corresponding screen command to start the service again.
+
+## See our excellent Documentation!
+<!--
+[Starting the container](Documentation/starting-the-container.md)
+
+[Importing an existing Magento shop into the Docker](Documentation/importing-a-shop.md)
+
+[Switching PHP versions](Documentation/switching-php-versions.md)
+
+[Debugging with Xdebug in PhpStorm](Documentation/debugging-with-xdebug-in-phpstorm.md)
+
+[Adding your own keys to the container](Documentation/adding-keys-to-container.md)
+
+[Inspecting emails sent from the Docker](Documentation/inspecting-emails.md)
+
+[Installing Magento 1](Documentation/magento-1-install.md)
+
+[Mac specific example](examples/osx_development/README.md) -->
+
+## Inspiration
+
+If you're wondering about how you can make best use of this image, check out some of these awesome project(s) by other users.
+
+### [Disposable Magento testing environments with Kubernetes](https://elgentos.nl/blog/disposable-magento-testing-environments-with-k8s/)
+
+[Peter Jaap Blaakmeer](https://github.com/peterjaap) explains how [Elgentos](https://elgentos.nl) automatically sets up disposable testing environments for branches, tags and commits in their repositories by deploying the `hypernode-docker` image on a Kubernetes cluster on the Google Cloud Platform.
+
+### [Local development with the Hypernode Docker container](https://blog.guapa.nl/local-development-with-the-hypernode-docker-container-linux?)
+
+[Ruthger Idema](https://github.com/ruthgeridema) describes how [Guapa](https://www.guapa.nl/) mimics their production environments as close as possible when developing on their local machines. Also includes a nice example for setting up Xdebug to work with PHPstorm in the `hypernode-docker`.
+
+### [WSL development environment for Hypernode Docker](https://github.com/frosit/hypernode-docker-wsl2)
+
+[Fabio Ros](https://github.com/frosit) over at [FROSIT](https://frosit.nl/) created a fully-featured [WSL](https://docs.microsoft.com/en-us/windows/wsl/) development environment that integrates nicely with WSL on your Windows PC and your PHPStorm/VSCode editor.
+Check out the sourcecode and how to set this up over at the open-source [`hypernode-docker-wsl2`](https://github.com/frosit/hypernode-docker-wsl2) repository.
+
+## Related projects
+
+### [hypernode-vagrant](https://github.com/ByteInternet/hypernode-vagrant)
+
+A similar local development or build environment based on [Vagrant](https://github.com/ByteInternet/hypernode-vagrant), using [Virtualbox](https://www.virtualbox.org/) VMs or [LXC](https://linuxcontainers.org/) containers. The difference between hypernode-docker and hypernode-vagrant is that the Vagrant has a complete init system, making it more like a real Hypernode, while the Docker could be more user-friendly depending on your environment and preferences.
+
+### [hypernode-deployment-hackathon](https://github.com/Hypernode/hypernode-deployment-hackathon)
+
+A work in progress Magento 2 module built by the community that can be used as a building block in combination with the Docker container in this repository to simplify the testing, building and deployment steps in your CI pipeline.

--- a/docs/best-practices/usage/hypernode-magerun-addons.md
+++ b/docs/best-practices/usage/hypernode-magerun-addons.md
@@ -5,19 +5,16 @@ myst:
     title: Hypernode Magerun Addons
 ---
 
-Hypernode Magerun Addons
-==============
-
-
+# Hypernode Magerun Addons
 
 Some additional commands for the excellent N98-magerun Magento command-line tool.
 
-| Master  |  [![Build Status](https://travis-ci.org/Hypernode/hypernode-magerun.svg?branch=master)](https://travis-ci.org/Hypernode/hypernode-magerun) |
-|------------|-------------------------------------------------|
-| Staging  | [![Build Status](https://travis-ci.org/Hypernode/hypernode-magerun.svg?branch=staging)](https://travis-ci.org/Hypernode/hypernode-magerun)  |
+| Master  | [![Build Status](https://travis-ci.org/Hypernode/hypernode-magerun.svg?branch=master)](https://travis-ci.org/Hypernode/hypernode-magerun)  |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Staging | [![Build Status](https://travis-ci.org/Hypernode/hypernode-magerun.svg?branch=staging)](https://travis-ci.org/Hypernode/hypernode-magerun) |
 
-Installation
-------------
+## Installation
+
 There are a few options.  You can check out the different options in the [Magerun
 docs](http://magerun.net/introducting-the-new-n98-magerun-module-system/).
 
@@ -25,89 +22,109 @@ Here's the easiest:
 
 1. Create ~/.n98-magerun/modules/ if it doesn't already exist.
 
-        mkdir -p ~/.n98-magerun/modules/
-        mkdir -p ~/.n98-magerun2/modules/
+   ```
+    mkdir -p ~/.n98-magerun/modules/
+    mkdir -p ~/.n98-magerun2/modules/
+   ```
 
-2. Clone the hypernode-magerun repository in there
+1. Clone the hypernode-magerun repository in there
 
-        git clone https://github.com/Hypernode/hypernode-magerun.git ~/.n98-magerun/modules/hypernode-magerun
+   ```
+    git clone https://github.com/Hypernode/hypernode-magerun.git ~/.n98-magerun/modules/hypernode-magerun
+   ```
 
-3. Link the repository for n98-magerun2
+1. Link the repository for n98-magerun2
 
-        ln -s ~/.n98-magerun/modules/hypernode-magerun ~/.n98-magerun2/modules/hypernode-magerun
+   ```
+    ln -s ~/.n98-magerun/modules/hypernode-magerun ~/.n98-magerun2/modules/hypernode-magerun
+   ```
 
-4. It should be installed. To see that it was installed, run magerun without any arguments to see if one of the new commands is in there.
+1. It should be installed. To see that it was installed, run magerun without any arguments to see if one of the new commands is in there.
 
-        n98-magerun.phar
+   ```
+    n98-magerun.phar
+   ```
 
-Commands
---------
+## Commands
 
-### Get a (system).log analyses of the most frequent lines ###
+### Get a (system).log analyses of the most frequent lines
 
-	n98-magerun hypernode:log-analyses
+```
+n98-magerun hypernode:log-analyses
+```
 
 Quickly reference the most common lines in the log file ordered by frequency.
 
-### Generate a boilerplate for Nginx http.magerunmaps ###
+### Generate a boilerplate for Nginx http.magerunmaps
 
-	n98-magerun hypernode:maps-generate
+```
+n98-magerun hypernode:maps-generate
+```
 
 Outputs or saves a http.magerunmaps boilerplate containing your store setup for Nginx. Refer to the [Hypernode Nginx documentation.](https://support.hypernode.com/knowledgebase/how-to-use-nginx/)
 
-### Varnish config ###
+### Varnish config
 
-	n98-magerun hypernode:varnish:config-save
+```
+n98-magerun hypernode:varnish:config-save
+```
 
 Fetches the VCL configuration from turpentine and applies it. Make sure [turpentine is installed and configured](https://support.hypernode.com/knowledgebase/varnish-on-hypernode/) correctly.
 
-### Flush all URL's in Varnish cache ###
+### Flush all URL's in Varnish cache
 
-	n98-magerun hypernode:varnish:flush
+```
+n98-magerun hypernode:varnish:flush
+```
 
 Flush all URL's that were cached by varnish.
 
-### Performance reporting ###
+### Performance reporting
 
-	n98-magerun hypernode:performance
+```
+n98-magerun hypernode:performance
+```
 
 By default this command loads Magento's sitemap collection from which you can choose what sitemaps you want to crawl. If the store URL does not match the URL's in the sitemap you will be prompted several options (compare, replace, continue). For instance the old and new URL can be compared in a performance report. Additionally a sitemap can be loaded by specifying a path or URL.
 
-### Checking for weak admin credentials ###
+### Checking for weak admin credentials
 
-    n98-magerun hypernode:crack:admin-passwords -r best64 vendors
+```
+n98-magerun hypernode:crack:admin-passwords -r best64 vendors
+```
 
 Check your site for weak admin credentials by attempting to brute force the password with popular password / variations.
 
-### Checking for weak admin credentials ###
+### Checking for weak admin credentials
 
-    n98-magerun hypernode:crack:api-keys -r best64 vendors
+```
+n98-magerun hypernode:crack:api-keys -r best64 vendors
+```
 
 This command words exactly the same as the `hypernode:crack:admin-passwords` except it attempts to crack the api_key of SOAP / XML-RPC users. All arguments are the same, check the commands `--help` for details.
 
-Packaging
---------
+## Packaging
 
 For development/testing (build package of your feature branch):
+
 ```
 gbp buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64
 ```
 
 Building a .deb for release:
+
 ```
 ./build.sh
 ```
 
 Then if everything is alright, upload the new version to your repository with something like [dput](http://manpages.ubuntu.com/manpages/precise/man1/dput.1.html)
 
-n98-magerun2 compatibility
------------------------
+## n98-magerun2 compatibility
 
 Currently, only the command `hypernode:perfomance` is partially compatible with n98-magerun2.
 
 Please contribute to make more commands available for n98-magerun2!
 
-Credits due where credits due
---------
+## Credits due where credits due
 
 Thanks to [Netz98](http://www.netz98.de) for creating the awesome Swiss army knife for Magento, [magerun](https://github.com/netz98/n98-magerun/).

--- a/docs/best-practices/usage/hypernode-magerun-addons.md
+++ b/docs/best-practices/usage/hypernode-magerun-addons.md
@@ -1,0 +1,113 @@
+---
+myst:
+  html_meta:
+    description: This article explains different addons for hypernode-magerun command.
+    title: Hypernode Magerun Addons
+---
+
+Hypernode Magerun Addons
+==============
+
+
+
+Some additional commands for the excellent N98-magerun Magento command-line tool.
+
+| Master  |  [![Build Status](https://travis-ci.org/Hypernode/hypernode-magerun.svg?branch=master)](https://travis-ci.org/Hypernode/hypernode-magerun) |
+|------------|-------------------------------------------------|
+| Staging  | [![Build Status](https://travis-ci.org/Hypernode/hypernode-magerun.svg?branch=staging)](https://travis-ci.org/Hypernode/hypernode-magerun)  |
+
+Installation
+------------
+There are a few options.  You can check out the different options in the [Magerun
+docs](http://magerun.net/introducting-the-new-n98-magerun-module-system/).
+
+Here's the easiest:
+
+1. Create ~/.n98-magerun/modules/ if it doesn't already exist.
+
+        mkdir -p ~/.n98-magerun/modules/
+        mkdir -p ~/.n98-magerun2/modules/
+
+2. Clone the hypernode-magerun repository in there
+
+        git clone https://github.com/Hypernode/hypernode-magerun.git ~/.n98-magerun/modules/hypernode-magerun
+
+3. Link the repository for n98-magerun2
+
+        ln -s ~/.n98-magerun/modules/hypernode-magerun ~/.n98-magerun2/modules/hypernode-magerun
+
+4. It should be installed. To see that it was installed, run magerun without any arguments to see if one of the new commands is in there.
+
+        n98-magerun.phar
+
+Commands
+--------
+
+### Get a (system).log analyses of the most frequent lines ###
+
+	n98-magerun hypernode:log-analyses
+
+Quickly reference the most common lines in the log file ordered by frequency.
+
+### Generate a boilerplate for Nginx http.magerunmaps ###
+
+	n98-magerun hypernode:maps-generate
+
+Outputs or saves a http.magerunmaps boilerplate containing your store setup for Nginx. Refer to the [Hypernode Nginx documentation.](https://support.hypernode.com/knowledgebase/how-to-use-nginx/)
+
+### Varnish config ###
+
+	n98-magerun hypernode:varnish:config-save
+
+Fetches the VCL configuration from turpentine and applies it. Make sure [turpentine is installed and configured](https://support.hypernode.com/knowledgebase/varnish-on-hypernode/) correctly.
+
+### Flush all URL's in Varnish cache ###
+
+	n98-magerun hypernode:varnish:flush
+
+Flush all URL's that were cached by varnish.
+
+### Performance reporting ###
+
+	n98-magerun hypernode:performance
+
+By default this command loads Magento's sitemap collection from which you can choose what sitemaps you want to crawl. If the store URL does not match the URL's in the sitemap you will be prompted several options (compare, replace, continue). For instance the old and new URL can be compared in a performance report. Additionally a sitemap can be loaded by specifying a path or URL.
+
+### Checking for weak admin credentials ###
+
+    n98-magerun hypernode:crack:admin-passwords -r best64 vendors
+
+Check your site for weak admin credentials by attempting to brute force the password with popular password / variations.
+
+### Checking for weak admin credentials ###
+
+    n98-magerun hypernode:crack:api-keys -r best64 vendors
+
+This command words exactly the same as the `hypernode:crack:admin-passwords` except it attempts to crack the api_key of SOAP / XML-RPC users. All arguments are the same, check the commands `--help` for details.
+
+Packaging
+--------
+
+For development/testing (build package of your feature branch):
+```
+gbp buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64
+```
+
+Building a .deb for release:
+```
+./build.sh
+```
+
+Then if everything is alright, upload the new version to your repository with something like [dput](http://manpages.ubuntu.com/manpages/precise/man1/dput.1.html)
+
+n98-magerun2 compatibility
+-----------------------
+
+Currently, only the command `hypernode:perfomance` is partially compatible with n98-magerun2.
+
+Please contribute to make more commands available for n98-magerun2!
+
+Credits due where credits due
+--------
+
+Thanks to [Netz98](http://www.netz98.de) for creating the awesome Swiss army knife for Magento, [magerun](https://github.com/netz98/n98-magerun/).

--- a/docs/hypernode-platform/api.md
+++ b/docs/hypernode-platform/api.md
@@ -1,0 +1,20 @@
+---
+myst:
+  html_meta:
+    description: This table of contents gives you a summary of all Hypernode platform
+      knowledge base articles that include information about varnish.
+    title: Hypernode-API | Hypernode platform
+redirect_from:
+  - /en/hypernode/api/
+---
+
+# API
+
+```{toctree}
+---
+caption: Table of Contents
+maxdepth: 1
+glob:
+---
+api/*
+```

--- a/docs/hypernode-platform/api/hypernode-api.md
+++ b/docs/hypernode-platform/api/hypernode-api.md
@@ -6,39 +6,48 @@ myst:
 ---
 
 # Welcome to the Hypernode-API (beta)
+
 First of, lets's be clear and mention that this API is still in beta and subject to change. So for now it's important
 to not let any of your critical systems depend on this API.
 
 ## Authentication
+
 To authenticate at the Hypernode-API you have to make use of the Hypernode-API token provisioned on your node. The
 location for this token is:
- ```
- /etc/hypernode/hypernode_api_token
- ```
+
+```
+/etc/hypernode/hypernode_api_token
+```
+
 You can use the value in this file to make requests
 to `https://api.hypernode.com` by specifying the token in the `Authorization` header like so:
+
 ```bash
 curl https://api.hypernode.com/v1/app/<your_app_name>/ -X GET --header "Authorization: Token <your_hypernode_api_token>"
 ```
+
 The API will return a 403 if you do not have permission to call a specified endpoint. If you do not authenticate the API
 will return a 401 response. If you encounter a 403 and would like to have access to the specified endpoint please feel
 free to contact our support department at support@hypernode.com.
 
 ## Functionalities
+
 ### Whitelisting
+
 Whitelisting allows you to add IP's for specific purposes. To find out how to use this have a look at [the documentation
 for this endpoint](/Documentation/hypernode-api/whitelisting/README.md).
 
 ### Hypernode settings
+
 This endpoint allows you to set settings for your Hypernode. For example, you can set your `php_version` or blackfire
-tokens here. To find out how to use this have a look at [the documentation for this endpoint](
-/Documentation/hypernode-api/settings/README.md).
+tokens here. To find out how to use this have a look at [the documentation for this endpoint](/Documentation/hypernode-api/settings/README.md).
 
 ### Chargebee SSO URL
+
 This endpoint allows you to retireve the SSO URL for Chargebee. If you are a customer which registered via Chargebee you
 will be able to retrieve the login URL for Chargebee which you can then use to login and manage your subscriptions.
-For more information about this endpoint have a look at [this endpoint's documentation](
-/Documentation/hypernode-api/chargebee/SSO/README.md).
+For more information about this endpoint have a look at [this endpoint's documentation](/Documentation/hypernode-api/chargebee/SSO/README.md).
 
 ### Perform preinstall
+
 This endpoint allows you to perform a preinstall of magento or akeneo on your Hypernode. For more information about this endpoint have a look at [this enpoint's documentation](/Documentation/hypernode-api/preinstall/README.md).

--- a/docs/hypernode-platform/api/hypernode-api.md
+++ b/docs/hypernode-platform/api/hypernode-api.md
@@ -1,0 +1,44 @@
+---
+myst:
+  html_meta:
+    description: Learn how to authenticate the Hypernode-API with your systems.
+    title: Hypernode-API | Hypernode
+---
+
+# Welcome to the Hypernode-API (beta)
+First of, lets's be clear and mention that this API is still in beta and subject to change. So for now it's important
+to not let any of your critical systems depend on this API.
+
+## Authentication
+To authenticate at the Hypernode-API you have to make use of the Hypernode-API token provisioned on your node. The
+location for this token is:
+ ```
+ /etc/hypernode/hypernode_api_token
+ ```
+You can use the value in this file to make requests
+to `https://api.hypernode.com` by specifying the token in the `Authorization` header like so:
+```bash
+curl https://api.hypernode.com/v1/app/<your_app_name>/ -X GET --header "Authorization: Token <your_hypernode_api_token>"
+```
+The API will return a 403 if you do not have permission to call a specified endpoint. If you do not authenticate the API
+will return a 401 response. If you encounter a 403 and would like to have access to the specified endpoint please feel
+free to contact our support department at support@hypernode.com.
+
+## Functionalities
+### Whitelisting
+Whitelisting allows you to add IP's for specific purposes. To find out how to use this have a look at [the documentation
+for this endpoint](/Documentation/hypernode-api/whitelisting/README.md).
+
+### Hypernode settings
+This endpoint allows you to set settings for your Hypernode. For example, you can set your `php_version` or blackfire
+tokens here. To find out how to use this have a look at [the documentation for this endpoint](
+/Documentation/hypernode-api/settings/README.md).
+
+### Chargebee SSO URL
+This endpoint allows you to retireve the SSO URL for Chargebee. If you are a customer which registered via Chargebee you
+will be able to retrieve the login URL for Chargebee which you can then use to login and manage your subscriptions.
+For more information about this endpoint have a look at [this endpoint's documentation](
+/Documentation/hypernode-api/chargebee/SSO/README.md).
+
+### Perform preinstall
+This endpoint allows you to perform a preinstall of magento or akeneo on your Hypernode. For more information about this endpoint have a look at [this enpoint's documentation](/Documentation/hypernode-api/preinstall/README.md).

--- a/docs/hypernode-platform/vpn.md
+++ b/docs/hypernode-platform/vpn.md
@@ -1,0 +1,20 @@
+---
+myst:
+  html_meta:
+    description: This table of contents gives you a summary of all Hypernode platform
+      knowledge base articles that include information about varnish.
+    title: VPN | Hypernode platform
+redirect_from:
+  - /en/hypernode/vpn/
+---
+
+# VPN
+
+```{toctree}
+---
+caption: Table of Contents
+maxdepth: 1
+glob:
+---
+vpn/*
+```

--- a/docs/hypernode-platform/vpn/how-to-use-hypernode-vpn.md
+++ b/docs/hypernode-platform/vpn/how-to-use-hypernode-vpn.md
@@ -1,51 +1,60 @@
 ---
 myst:
   html_meta:
-    description: 'Hypernode-vpn offers a secure way of directly connecting to your database from any location.
- See intstructions that guide you through the process. '
+    description: 'Hypernode-vpn offers a secure way of directly connecting to your
+      database from any location. See intstructions that guide you through the process. '
     title: How to use hypernode-vpn?
 redirect_from:
   - /en/hypernode/vpn/how-to-use-hypernode-vpn/
 ---
 
-
 # Hypernode-vpn documentation
+
 Hypernode-vpn offers a secure way of directly connecting to your database from any location.
 Using [OpenVPN](https://openvpn.net/).
 
 ### How it works
+
 Our Hypernode-vpn solution implements a standard OpenVPN TLS tunnel to the Hypernode.
 Which can be used to talk to the MySQL database securely.
 You simply enable OpenVPN on your Hypernode and all the required packages and configuration are installed automatically.
 The automation will generate a default user configuration which you can use to connect to the Hypernode.
 
 ### Using OpenVPN
+
 To be able to connect to your Hypernode you will need to install the latest version of the
 [OpenVPN client](https://openvpn.net/index.php/open-source/downloads.html).
 
 ### Enable / Disable
+
 This can simply be done on the Hypernode itself.
- ```
- hypernode-systemctl settings openvpn_enabled --value <True/False>
- ```
+
+```
+hypernode-systemctl settings openvpn_enabled --value <True/False>
+```
+
 This command will trigger the Hypernode automation to start installing OpenVPN and generate the configuration.
 Or delete all the configuration when disabling.
 
 ### Client configuration
+
 After the installation process is complete the client configuration can be found in `/data/openvpn/client-configs`.
 Normally the standard configuration will be called something like `openvpnclient.<appname>.<domain>.ovpn`.
 Place this file in your OpenVPN config directory on your PC/device.
 This file contains the OpenVPN private key for you Hypernode, so keep it secure!
 
 ### Connecting
+
 When you have downloaded your client configuration use it to connect to your Hypernode.
 
 Linux example
+
 ```
 $ sudo openvpn --config /etc/openvpn/openvpnclient.erikhyperdev.hypernode.io
 ```
 
 Windows example
+
 ```
 # Make sure the client config is placed in the correct directory
 # Normally this is C:/ProgramFiles/OpenVPN/config
@@ -54,11 +63,13 @@ SystemTray -> OpenVPN-GUI -> openvpnclient.erikhyperdev.hypernode.io -> Connect
 ```
 
 ### Using OpenVPN
+
 Once connected the standard configuration will make a new tunnel interface on your local device.
 The `192.168.255.0/24` subnet will be used for VPN communication.
 So when talking to the Hypernode by default use `192.168.255.1` as the IP address.
 
 MySQL example:
+
 ```
 $ mysql -u app -p -h 192.168.255.1
 Enter password:

--- a/docs/hypernode-platform/vpn/how-to-use-hypernode-vpn.md
+++ b/docs/hypernode-platform/vpn/how-to-use-hypernode-vpn.md
@@ -1,3 +1,14 @@
+---
+myst:
+  html_meta:
+    description: 'Hypernode-vpn offers a secure way of directly connecting to your database from any location.
+ See intstructions that guide you through the process. '
+    title: How to use hypernode-vpn?
+redirect_from:
+  - /en/hypernode/vpn/how-to-use-hypernode-vpn/
+---
+
+
 # Hypernode-vpn documentation
 Hypernode-vpn offers a secure way of directly connecting to your database from any location.
 Using [OpenVPN](https://openvpn.net/).

--- a/docs/hypernode-platform/vpn/how-to-use-hypernode-vpn.md
+++ b/docs/hypernode-platform/vpn/how-to-use-hypernode-vpn.md
@@ -1,0 +1,67 @@
+# Hypernode-vpn documentation
+Hypernode-vpn offers a secure way of directly connecting to your database from any location.
+Using [OpenVPN](https://openvpn.net/).
+
+### How it works
+Our Hypernode-vpn solution implements a standard OpenVPN TLS tunnel to the Hypernode.
+Which can be used to talk to the MySQL database securely.
+You simply enable OpenVPN on your Hypernode and all the required packages and configuration are installed automatically.
+The automation will generate a default user configuration which you can use to connect to the Hypernode.
+
+### Using OpenVPN
+To be able to connect to your Hypernode you will need to install the latest version of the
+[OpenVPN client](https://openvpn.net/index.php/open-source/downloads.html).
+
+### Enable / Disable
+This can simply be done on the Hypernode itself.
+ ```
+ hypernode-systemctl settings openvpn_enabled --value <True/False>
+ ```
+This command will trigger the Hypernode automation to start installing OpenVPN and generate the configuration.
+Or delete all the configuration when disabling.
+
+### Client configuration
+After the installation process is complete the client configuration can be found in `/data/openvpn/client-configs`.
+Normally the standard configuration will be called something like `openvpnclient.<appname>.<domain>.ovpn`.
+Place this file in your OpenVPN config directory on your PC/device.
+This file contains the OpenVPN private key for you Hypernode, so keep it secure!
+
+### Connecting
+When you have downloaded your client configuration use it to connect to your Hypernode.
+
+Linux example
+```
+$ sudo openvpn --config /etc/openvpn/openvpnclient.erikhyperdev.hypernode.io
+```
+
+Windows example
+```
+# Make sure the client config is placed in the correct directory
+# Normally this is C:/ProgramFiles/OpenVPN/config
+Start OpenVPN-GUI
+SystemTray -> OpenVPN-GUI -> openvpnclient.erikhyperdev.hypernode.io -> Connect
+```
+
+### Using OpenVPN
+Once connected the standard configuration will make a new tunnel interface on your local device.
+The `192.168.255.0/24` subnet will be used for VPN communication.
+So when talking to the Hypernode by default use `192.168.255.1` as the IP address.
+
+MySQL example:
+```
+$ mysql -u app -p -h 192.168.255.1
+Enter password:
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 540
+Server version: 5.6.37-82.2-log Percona Server (GPL), Release 82.2, Revision d1eb51005df
+
+Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```


### PR DESCRIPTION
We want to get rid of community docs as it's not being updated, so I copied last leftovers from community docs to regular docs. 

@vdloo please decide which of hypernode-docker doc is more accurate and relevant. /testing/how-to-use-hypernode.docker.md (copied from community) or /testing/hypernode-docker (was on docs already) 