### PR TITLE
Update how-to-use-alternative-php-versions.md

### DIFF
--- a/docs/hypernode-platform/php/how-to-use-alternative-php-versions.md
+++ b/docs/hypernode-platform/php/how-to-use-alternative-php-versions.md
@@ -21,7 +21,7 @@ You can list, enable and disable the alternative PHP versions on your Hypernode 
 To list the enabled alternative PHP versions, you can use the following command:
 
 ```bash
-hypernode-systemctl settings alternative_php_versions list
+hypernode-systemctl settings alternative_php_versions
 ```
 
 The output will tell you the enabled PHP versions, please note that this does not contain your main system PHP version.


### PR DESCRIPTION
Change command since `list` argument does not exsist?

```
app@nmsby6-aquive-magweb-cmbl ~ $ hypernode-systemctl settings alternative_php_versions list
list is not an allowed value for attribute alternative_php_versions. Choices are ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3'].
app@nmsby6-aquive-magweb-cmbl ~ $ hypernode-systemctl settings alternative_php_versions
alternative_php_versions is set to value 8.2
```
