### PR TITLE
docs/hypernode-deploy: Update image versions

### DIFF
--- a/docs/hypernode-deploy/getting-started/configure-ci-cd.md
+++ b/docs/hypernode-deploy/getting-started/configure-ci-cd.md
@@ -103,8 +103,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Here we use the Hypernode Deploy v3 image with PHP 8.1 and Node.js 18
-    container: quay.io/hypernode/deploy:3.0-php8.1-node18
+    # Here we use the Hypernode Deploy v4 image with PHP 8.3 and Node.js 20
+    container: quay.io/hypernode/deploy:4-php8.3-node20
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -137,8 +137,8 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    # Here we use the Hypernode Deploy v3 image with PHP 8.1 and Node.js 18
-    container: quay.io/hypernode/deploy:3.0-php8.1-node18
+    # Here we use the Hypernode Deploy v4 image with PHP 8.3 and Node.js 20
+    container: quay.io/hypernode/deploy:4-php8.3-node20
     steps:
       - uses: actions/checkout@v2
       - name: download build artifact

--- a/docs/hypernode-deploy/pipelines/bitbucket-pipelines.md
+++ b/docs/hypernode-deploy/pipelines/bitbucket-pipelines.md
@@ -58,7 +58,7 @@ Create the file `bitbucket-pipelines.yml` with the contents below.
 This workflow will be used in other workflows.
 
 ```yaml
-image: quay.io/hypernode/deploy:3-php8.2-node18
+image: quay.io/hypernode/deploy:4-php8.3-node20
 
 definition:
   steps:
@@ -76,7 +76,7 @@ For example, if your project needs PHP 7.4 and Node.js 16, set the image to:
 ```yaml
 jobs:
   build:
-    container: quay.io/hypernode/deploy:3-php7.4-node16
+    image: quay.io/hypernode/deploy:4-php7.4-node16
     ...
 ```
 ````

--- a/docs/hypernode-deploy/pipelines/github-actions.md
+++ b/docs/hypernode-deploy/pipelines/github-actions.md
@@ -57,7 +57,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: quay.io/hypernode/deploy:3-php8.1-node18
+    container: quay.io/hypernode/deploy:4-php8.3-node20
     steps:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3
@@ -82,7 +82,7 @@ For example, if your project needs PHP 7.4 and Node.js 16, set the image to:
 ```yaml
 jobs:
   build:
-    container: quay.io/hypernode/deploy:3-php7.4-node16
+    container: quay.io/hypernode/deploy:4-php7.4-node16
     ...
 ```
 ````
@@ -112,7 +112,7 @@ jobs:
     environment:
       name: production
       url: https://www.example.com
-    container: quay.io/hypernode/deploy:3-php8.1-node18
+    container: quay.io/hypernode/deploy:4-php8.3-node20
     steps:
     - uses: actions/checkout@v3
     - name: download build artifact
@@ -156,7 +156,7 @@ jobs:
     environment:
       name: acceptance
       url: https://acceptance.example.com
-    container: quay.io/hypernode/deploy:3-php8.1-node18
+    container: quay.io/hypernode/deploy:4-php8.3-node20
     steps:
     - uses: actions/checkout@v3
     - name: download build artifact

--- a/docs/hypernode-deploy/pipelines/gitlab-ci.md
+++ b/docs/hypernode-deploy/pipelines/gitlab-ci.md
@@ -49,7 +49,7 @@ This sets the container image, defines the CI/CD stages and defines the build st
 
 ```yaml
 # See https://quay.io/repository/hypernode/deploy?tab=tags for all possible tags.
-image: quay.io/hypernode/deploy:3-php8.1-node18
+image: quay.io/hypernode/deploy:4-php8.3-node20
 
 stages:
   - build
@@ -72,7 +72,7 @@ build:
 Don't forget to set the specifications of the image to what your project needs.
 For example, if your project needs PHP 7.4 and Node.js 16, set the image to:
 ```yaml
-image: quay.io/hypernode/deploy:3-php7.4-node16
+image: quay.io/hypernode/deploy:4-php7.4-node16
 ```
 ````
 


### PR DESCRIPTION
Major version v4 came out and PHP 8.3 is a bit more likely to be used nowadays.