### PR TITLE
move magento2 OS HMV section to hypernode-managed-vhosts.md and link to it

### DIFF
--- a/docs/ecommerce-applications/magento-2/how-to-configure-remote-storage-for-magento-2-x.md
+++ b/docs/ecommerce-applications/magento-2/how-to-configure-remote-storage-for-magento-2-x.md
@@ -95,29 +95,8 @@ Magento's S3 implementation creates a test file called `storage.flag`, which is 
 
 ## Serving assets from your S3 bucket
 
-To serve media assets directly from your S3 bucket, you need to adjust your Nginx configuration.
-Fortunately, `hypernode-manage-vhosts` simplifies this process for you.
-If you're using Hypernode's object storage solution, simply run the following command for the relevant vhosts:
-
-```bash
-hmv example.com --object-storage
-```
-
-### Using a custom object storage solution
-
-If you're using a custom storage provider, such as Amazon S3, you'll need to specify the bucket name and URL manually:
-
-```bash
-hmv example.com --object-storage --object-storage-bucket mybucket --object-storage-url https://example_url.com
-```
-
-### Switching back to Hypernode defaults
-
-If you previously set a custom bucket and URL but want to revert to Hypernode's default object storage, use the `--object-storage-defaults` flag:
-
-```bash
-hmv example.com --object-storage-defaults
-```
+To serve media assets directly from your S3 bucket, you need to adjust your nginx configuration.
+Fortunately, `hypernode-manage-vhosts` ([simplifies this process for you](../../hypernode-platform/nginx/hypernode-managed-vhosts.md)).
 
 ### Configuring Amazon S3 bucket policies
 

--- a/docs/ecommerce-applications/magento-2/how-to-configure-remote-storage-for-magento-2-x.md
+++ b/docs/ecommerce-applications/magento-2/how-to-configure-remote-storage-for-magento-2-x.md
@@ -96,7 +96,7 @@ Magento's S3 implementation creates a test file called `storage.flag`, which is 
 ## Serving assets from your S3 bucket
 
 To serve media assets directly from your S3 bucket, you need to adjust your nginx configuration.
-Fortunately, `hypernode-manage-vhosts` ([simplifies this process for you](../../hypernode-platform/nginx/hypernode-managed-vhosts.md)).
+Fortunately, `hypernode-manage-vhosts` ([simplifies this process for you](../../hypernode-platform/nginx/hypernode-managed-vhosts.md#object-storage-and-hypernode-managed-vhosts)).
 
 ### Configuring Amazon S3 bucket policies
 

--- a/docs/ecommerce-applications/magento-2/how-to-configure-remote-storage-for-magento-2-x.md
+++ b/docs/ecommerce-applications/magento-2/how-to-configure-remote-storage-for-magento-2-x.md
@@ -96,7 +96,7 @@ Magento's S3 implementation creates a test file called `storage.flag`, which is 
 ## Serving assets from your S3 bucket
 
 To serve media assets directly from your S3 bucket, you need to adjust your nginx configuration.
-Fortunately, `hypernode-manage-vhosts` ([simplifies this process for you](../../hypernode-platform/nginx/hypernode-managed-vhosts.md#object-storage-and-hypernode-managed-vhosts)).
+Fortunately, `hypernode-manage-vhosts` [simplifies this process for you](../../hypernode-platform/nginx/hypernode-managed-vhosts.md#object-storage-and-hypernode-managed-vhosts).
 
 ### Configuring Amazon S3 bucket policies
 

--- a/docs/hypernode-platform/nginx/hypernode-managed-vhosts.md
+++ b/docs/hypernode-platform/nginx/hypernode-managed-vhosts.md
@@ -91,7 +91,7 @@ If you're using object storage with Magento 2.x or Shopware 6.x you can use HMV 
 If you're using Hypernode's object storage solution, simply run the following command for the relevant vhosts:
 
 ```bash
-hmv example.com --object-storage
+hypernode-manage-vhosts example.com --object-storage
 ```
 
 ### Using a custom object storage solution
@@ -99,7 +99,7 @@ hmv example.com --object-storage
 If you're using a custom storage provider, such as Amazon S3, you'll need to specify the bucket name and URL manually:
 
 ```bash
-hmv example.com --object-storage --object-storage-bucket mybucket --object-storage-url https://example_url.com
+hypernode-manage-vhosts example.com --object-storage --object-storage-bucket mybucket --object-storage-url https://example_url.com
 ```
 
 ### Switching back to Hypernode defaults
@@ -107,7 +107,7 @@ hmv example.com --object-storage --object-storage-bucket mybucket --object-stora
 If you previously set a custom bucket and URL but want to revert to Hypernode's default object storage, use the `--object-storage-defaults` flag:
 
 ```bash
-hmv example.com --object-storage-defaults
+hypernode-manage-vhosts example.com --object-storage-defaults
 ```
 
 ## Managing Configuration Files

--- a/docs/hypernode-platform/nginx/hypernode-managed-vhosts.md
+++ b/docs/hypernode-platform/nginx/hypernode-managed-vhosts.md
@@ -84,6 +84,32 @@ Once the command is processed you could list all the vhosts to check if Varnish 
 
 To disable Varnish for a vhost, use the following command: `hypernode-manage-vhosts example.com --disable-varnish`
 
+## Object Storage and Hypernode Managed Vhosts
+
+If you're using object storage with Magento 2.x or Shopware 6.x you can use HMV to adjust your nginx config to serve assets directly from your bucket.
+
+If you're using Hypernode's object storage solution, simply run the following command for the relevant vhosts:
+
+```bash
+hmv example.com --object-storage
+```
+
+### Using a custom object storage solution
+
+If you're using a custom storage provider, such as Amazon S3, you'll need to specify the bucket name and URL manually:
+
+```bash
+hmv example.com --object-storage --object-storage-bucket mybucket --object-storage-url https://example_url.com
+```
+
+### Switching back to Hypernode defaults
+
+If you previously set a custom bucket and URL but want to revert to Hypernode's default object storage, use the `--object-storage-defaults` flag:
+
+```bash
+hmv example.com --object-storage-defaults
+```
+
 ## Managing Configuration Files
 
 ### Vhost-specific configuration


### PR DESCRIPTION
So that I can link to it later on in the Shopware 6.x OS documentation