### PR TITLE
Change wp-cron to a PHP CLI command instead of curling (which gets blocked by our security rules)

### DIFF
--- a/docs/ecommerce-applications/woocommerce/how-to-set-up-a-cron-job-for-wordpress-woocommerce-on-hypernode.md
+++ b/docs/ecommerce-applications/woocommerce/how-to-set-up-a-cron-job-for-wordpress-woocommerce-on-hypernode.md
@@ -15,7 +15,7 @@ In this guide, we'll explain how to replace the default WordPress cron job with 
 
 To begin, disable the default WordPress cron by editing the wp-config.php file.
 
-Connect to your server using an FTP client like FileZilla or an SSH client such as PuTTY. Navigate to the root directory of your WordPress installation and locate the `wp-config.php` file. Open the file for editing and add the following line of code before `/* That’s all. Stop editing! Happy blogging. */`:
+Connect to your server using an FTP client like FileZilla or an SSH client such as PuTTY. Navigate to the root directory of your WordPress installation and locate the `wp-config.php` file. Open the file for editing and add the following line of code before `/* That's all. Stop editing! Happy blogging. */`:
 
 ```php
 define('DISABLE_WP_CRON', true);
@@ -34,15 +34,15 @@ app@abcdef-example-magweb-cmbl ~ $ crontab -e
 Add the following line to your crontab file to set up a cron job that runs every minute:
 
 ```console
-* * * * * /usr/bin/chronic wget -q -O - 'https://yourdomain.hypernode.io/wp-cron.php?doing_wp_cron'
+* * * * * /usr/bin/chronic php /data/web/public/wp-cron.php > /dev/null 2>&1
 ```
 
-Replace `https://yourdomain.hypernode.io` with the actual URL of your WordPress site.
+**Note:** Make sure to replace `/data/web/public/wp-cron.php` with the actual path to your WordPress installation if it's different from the default path. The default WordPress installation path on Hypernode is typically `/data/web/public/`.
 
-Explanation of the Cron Job Command
+### Explanation of the Cron Job Command
 
 - `* * * * *`: Specifies the interval for the cron job. In this case, it is set to run every minute. You can adjust this based on your needs.
-- `wget -q -O - 'https://yourdomain.hypernode.io/wp-cron.php?doing_wp_cron'`: Uses wget to make a web request to the WordPress cron URL, triggering any scheduled tasks.
-- `>/dev/null 2>&1`: Discards any output from the command, preventing it from filling up your server logs.
+- `php /data/web/public/wp-cron.php`: Directly executes the WordPress cron script using PHP, eliminating the need for an HTTP request.
+- `> /dev/null 2>&1`: Discards any output from the command, preventing it from filling up your server logs.
 
 After setting up your cron job, monitor your WordPress site to ensure that scheduled tasks are being executed as expected. This setup ensures that your WordPress or WooCommerce site on Hypernode handles scheduled tasks more reliably, especially under conditions where the default cron system may not suffice.


### PR DESCRIPTION
Closes https://github.com/ByteInternet/hypernode-docs-next/issues/353