### PR TITLE
Update how-to-run-rabbitmq-on-hypernode.md

### DIFF
--- a/docs/best-practices/database/how-to-run-rabbitmq-on-hypernode.md
+++ b/docs/best-practices/database/how-to-run-rabbitmq-on-hypernode.md
@@ -85,7 +85,7 @@ To configure RabbitMQ in Magento 2, you can run the following command:
 
 ```bash
 bin/magento setup:config:set \
-    --amqp-host="rabbitmqmaster" \
+    --amqp-host="rabbitmq" \
     --amqp-port="5672" \
     --amqp-user="guest" \
     --amqp-password="guest" \


### PR DESCRIPTION
fix: Use the correct hostname for the setup

Apparently the hostname is rabbitmq and not rabbitmqmaster. 127.0.0.1 as host will also work since the guest/guest configuration of RabbitMQ is requiring  to work from localhost.