### PR TITLE
Remove sphinxcontrib-mermaid dependency

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
     },
     "vscode": {
       "extensions": [
-        "bierner.markdown-mermaid",
         "davidanson.vscode-markdownlint",
         "ms-python.python"
       ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,6 @@ extensions = [
     "hypernode.sphinx.extensions.updated_at",
     "hypernode.sphinx.extensions.meta_robots",
     "hypernode.sphinx.extensions.github_actions_logging",
-    "sphinxcontrib.mermaid",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,6 @@ mdformat-frontmatter==0.4.1
 sphinx-notfound-page==0.8.3
 sphinx-sitemap==2.4.0
 GitPython==3.1.30
-sphinxcontrib-mermaid==0.7.1
 
 # hypernode/ requirements
 beautifulsoup4==4.11.1


### PR DESCRIPTION
Their cdn has been down a few times causing long loadtimes, and we don't use mermaid, so it's better to remove this entirely from the project.