### PR TITLE
Added fix for nginx configuration using Gutenberg editor

### DIFF
--- a/docs/best-practices/usage/how-to-install-wordpress-next-to-your-magento-installation.md
+++ b/docs/best-practices/usage/how-to-install-wordpress-next-to-your-magento-installation.md
@@ -85,7 +85,7 @@ Create a `/data/web/nginx/server.wordpress` with the following content:
 location /blog {
     root /data/web/public;
     index index.php;
-    try_files $uri $uri/ /blog/index.php;
+    try_files $uri $uri/ /blog/index.php$is_args$args;
 
     location ~ \.php$ {
         echo_exec @phpfpm;


### PR DESCRIPTION
wp-json lookup calls with parameters were failing. e.g. Adding tags and categories when using the Gutenberg editor.

Key source:
https://stackoverflow.com/questions/30379940/how-do-i-get-the-wordpress-json-api-to-work-on-nginx-server/50734661#50734661