### PR TITLE
Update configure-ci-cd.md

### DIFF
--- a/docs/hypernode-deploy/getting-started/configure-ci-cd.md
+++ b/docs/hypernode-deploy/getting-started/configure-ci-cd.md
@@ -120,7 +120,7 @@ jobs:
         env:
           DEPLOY_COMPOSER_AUTH: ${{ secrets.DEPLOY_COMPOSER_AUTH }}
       - name: archive production artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: deployment-build
           path: build/build.tgz


### PR DESCRIPTION
A few tweaks here to update github action

## Update actions to supported versions
```bash
actionlint .github/workflows/hypernode-deploy.yml
.github/workflows/hypernode-deploy.yml:16:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
16 |       - uses: actions/checkout@v2
   |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/hypernode-deploy.yml:17:15: the runner of "actions/cache@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
17 |       - uses: actions/cache@v2
   |               ^~~~~~~~~~~~~~~~
```

This action was also prohibited without an upgrade https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Add a retention limit to the deploy artifact

To keep storage costs under control, by default aritfacts are stored for 90 days. A magento artifact can easilly be +500MB so these can add up quickly when deployments to staging are made.

## Add `run-name` for variable name

This allows us to see which specific branch triggered the deployment from within the github actions UI

You can see my image example
<img width="568" height="157" alt="Screenshot 2025-10-01 at 14 51 31" src="https://github.com/user-attachments/assets/97a49799-aadc-4b47-8e8d-b324078916c0" />

The top build was triggered with the following, which dynamically updates the run name based on the deployed branch.  
```yml
name: 
run-name: Hypernode Deploy – ${{ github.ref_name }}
```

This can be very useful for spotting production deploys in a sea of staging deployments.

