### PR TITLE
Fix IP whitelist value in "Whitelisting Based on IP and User Agent"

### DIFF
--- a/docs/hypernode-platform/nginx/basic-authentication-on-hypernode-development-plans.md
+++ b/docs/hypernode-platform/nginx/basic-authentication-on-hypernode-development-plans.md
@@ -121,7 +121,7 @@ In the **nginx** file named **whitelist-development-exception.conf**, you should
 ```nginx
 geo $ip_whitelist {
     default "Development restricted area";
-    # 1.2.3.4 1; # IP address whitelist
+    # 1.2.3.4 "off"; # IP address whitelist
 }
 
 map $http_user_agent $development_exceptions {


### PR DESCRIPTION
This fix corrects a syntax error in the `whitelist-development-exception.conf` example code. The `geo` directive in nginx uses string values, and the whitelist configuration should use `"off"` rather than `1` to properly disable access for non-whitelisted IPs.