### PR TITLE
fix: allow fork PRs to access secrets in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Deploy application
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - 'master'
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # Declares the repository safe and not under dubious ownership.
       - name: Add repository to git safe directories
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
@@ -52,6 +53,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: download build artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,7 @@
 name: Run linting and suggest changes
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read
@@ -15,8 +15,10 @@ jobs:
         python-version: ['3.12']
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Use pull_request_target instead of pull_request to run the workflow in the context of the base repository, enabling secrets access for fork PRs. Explicitly checkout PR head SHA to build the correct code.