### PR TITLE
Update known plugins for rate limiting documentation

### DIFF
--- a/docs/hypernode-platform/nginx/how-to-resolve-rate-limited-requests-429-too-many-requests.md
+++ b/docs/hypernode-platform/nginx/how-to-resolve-rate-limited-requests-429-too-many-requests.md
@@ -116,6 +116,7 @@ There are a couple of plugins and service providers that tend to hit the blackli
 - MailPlus - `Jersey/2.23.1`
 - Mollie - `Mollie.nl HTTP client/1.0`
 - Screaming - `Screaming Frog SEO Spider`
+- Cloudflare Healthchecks - `Cloudflare-Healthchecks`
 
 Besides the above-known plugins that will hit the blacklisted keyword, `http.ratelimit` we know that Picqer will also hit the rate limiter because of being blocked by "**zoneperip**". Please find [here](https://picqer.com/files/ip-addresses.txt) the IP addresses of Picqer. You can exclude those IP addresses from hitting the rate limiter if you follow the [instructions](#known-rate-limited-plugins-and-service-providers).
 

--- a/docs/hypernode-platform/nginx/how-to-resolve-rate-limited-requests-429-too-many-requests.md
+++ b/docs/hypernode-platform/nginx/how-to-resolve-rate-limited-requests-429-too-many-requests.md
@@ -108,7 +108,7 @@ Instead of adding the complete User Agent to the regex, it’s often better to l
 
 ### Known Rate Limited Plugins and Service Providers
 
-There are a couple of plugins and service providers that tend to hit the blacklisted keyword in the `http.ratelimit` snippet and, therefore, may need to be excluded individually. Below we have listed them and their User Agents for your convenience
+There are a couple of plugins and service providers that tend to hit the blacklisted keyword in the `http.ratelimit` snippet and, therefore, may need to be excluded individually. Below we have listed some popular services and their User Agents for your convenience
 
 - Adyen - `Jakarta Commons-HttpClient/3.0.1`
 - Adyen - `Apache-HttpClient/4.4.1 (Java/1.8.0_74)`


### PR DESCRIPTION
Added Cloudflare Healthchecks to the list of known plugins that trigger rate limiting.