### PR TITLE
ssl: Add specific article for custom certs

### DIFF
--- a/docs/best-practices/cdn/how-to-use-cloudflare-with-hypernode.md
+++ b/docs/best-practices/cdn/how-to-use-cloudflare-with-hypernode.md
@@ -54,6 +54,8 @@ Cloudflare offers SSL offloading. You can upload your SSL certificates to Cloudf
 
 If you use manual SSL certificates, make sure you monitor when your certificate is about to expire.
 
+You can also use a [Cloudflare Origin CA certificate](../../hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md#use-a-cloudflare-origin-ca-certificate) to encrypt traffic between Cloudflare and your Hypernode.
+
 ## Redirection From HTTP to HTTP
 
 Redirecting from HTTP to HTTPS can cause a *Too many redirects* error. This error comes from a cached redirect that is served on both HTTP and HTTPS connection, causing the site to redirect from HTTP to HTTPS.

--- a/docs/best-practices/cdn/how-to-use-cloudflare-with-hypernode.md
+++ b/docs/best-practices/cdn/how-to-use-cloudflare-with-hypernode.md
@@ -8,8 +8,6 @@ redirect_from:
   - /en/best-practices/cdn/how-to-use-cloudflare-with-hypernode/
 ---
 
-<!-- source: https://support.hypernode.com/en/best-practices/cdn/how-to-use-cloudflare-with-hypernode/ -->
-
 # How to Use Cloudflare with Hypernode
 
 To get started with Cloudflare on your Hypernode create an account at Cloudflare and change the nameservers of your domain to the Cloudflare nameservers.
@@ -30,7 +28,7 @@ Cloudflare blocks threats, limits abusive bots and crawlers from wasting your ba
 
 To setup Cloudflare for your shop, use the following steps:
 
-1. Create an [account at Cloudflare](https://support.cloudflare.com/hc/en-us/articles/201720164-How-do-I-sign-up-for-CloudFlare-)
+1. Create an [account at Cloudflare](https://developers.cloudflare.com/fundamentals/account/create-account/)
 1. Login to your [Cloudflare admin panel](https://www.cloudflare.com/a/login)
 1. Turn on caching and other performance optimization.
 1. Copy all DNS Records from your current domain provider to the Cloudflare DNS admin
@@ -42,25 +40,19 @@ To setup Cloudflare for your shop, use the following steps:
    Mirage mobile image optimization
 1. Test, test some more and after that, test it all again.
 
-## Configuration of Cloudflare for Magento
-
-Cloudflare provides [a very large knowledge base](https://support.cloudflare.com/hc/en-us) for dealing with a wide variety of issues and optimizations.
-
-For using Cloudflare with Magento, please check [the article on their knowledge base](https://support.cloudflare.com/hc/en-us/articles/203904600-Using-CloudFlare-with-Magento) and their [Page Rules and Magento optimization article](https://www.cloudflare.com/features-page-rules/optimize-magento/).
-
 ## Using SSL With Cloudflare
 
 Cloudflare offers SSL offloading. You can upload your SSL certificates to Cloudflare to make use of SSL. If you choose to do this, always manually order your SSL certificates so you can use the same certificate on both the Cloudflare servers and the Hypernode.
 
 If you use manual SSL certificates, make sure you monitor when your certificate is about to expire.
 
-You can also use a [Cloudflare Origin CA certificate](../../hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md#use-a-cloudflare-origin-ca-certificate) to encrypt traffic between Cloudflare and your Hypernode.
+You can also use a [Cloudflare Origin CA certificate](../../hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md#use-a-cloudflare-origin-ca-certificate) to encrypt traffic between Cloudflare and your Hypernode using a certificate signed by Cloudflare. This way you can use Cloudflare SSL/TLS mode **Full (Strict)** without having to worry about your certificate expiring.
 
-## Redirection From HTTP to HTTP
+## Redirection From HTTP to HTTPS
 
 Redirecting from HTTP to HTTPS can cause a *Too many redirects* error. This error comes from a cached redirect that is served on both HTTP and HTTPS connection, causing the site to redirect from HTTP to HTTPS.
 
-To redirect all requests to HTTPS when using Cloudflare SSL, you should instead use [a page rule with the Always Use HTTPS action.](https://support.cloudflare.com/hc/en-us/articles/203295200-End-to-end-HTTPS-with-Cloudflare-Part-2-SSL-certificates)
+To redirect all requests to HTTPS when using Cloudflare SSL, you should instead use [the Always Use HTTPS](https://developers.cloudflare.com/ssl/edge-certificates/additional-options/always-use-https/#encrypt-all-visitor-traffic) setting.
 
 ## Blocking IP’s When Using Cloudflare
 
@@ -71,16 +63,6 @@ This way you can block remote visitors without blocking all traffic coming from 
 For example have a look at [our documentation about blocking or whitelisting IP’s in Nginx](../../hypernode-platform/nginx/how-to-block-allow-ip-addresses-in-nginx.md).
 
 Another option is to configure a blocklist in the [Cloudflare Admin](https://www.cloudflare.com/a/login).
-
-## Don’t Use Railgun on Hypernodes
-
-Cloudflare provides a service called [Railgun.](https://blog.cloudflare.com/cacheing-the-uncacheable-cloudflares-railgun-73454/) The key to this service is a local proxy daemon that sends all requests from Cloudflare through a tunnel to the proxy instance that does the actual web requests.
-
-Our tests with Railgun on Hypernodes showed a performance gain of just a few milliseconds, making it not a very significant performance optimization when working with Magento.
-
-As we do not support Railgun (yet), we’ve seen some implementations running the Railgun daemon on a separate server. Doing so is not recommended as it will make all HTTP requests from Cloudflare arrive from the same remote IP.
-
-When someone is trying to brute force your server or in case of an attack, our protection mechanisms will block the attacker. When you use Railgun, our mechanisms will not block the remote IP but block the IP of the Railgun daemon instead, blocking all traffic coming from Cloudflare and therefore block all visitors to your shop.
 
 ## 520 Errors From Cloudflare
 

--- a/docs/hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md
+++ b/docs/hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md
@@ -59,7 +59,7 @@ If you want to check which custom SSL certificates are linked to a specific Hype
 
 ## Use a Cloudflare Origin CA Certificate
 
-Cloudflare Origin CA certificates encrypt traffic between Cloudflare and your Hypernode. They are useful when your domain uses Cloudflare proxying and you want to use Cloudflare SSL/TLS mode **Full (strict)**. For more information, see the [official Cloudflare Origin CA documentation](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/).
+Cloudflare Origin CA certificates encrypt traffic between Cloudflare and your Hypernode. They are useful when your domain uses Cloudflare proxying and you want to use Cloudflare SSL/TLS mode **Full (Strict)**. For more information, see the [official Cloudflare Origin CA documentation](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/).
 
 ```{warning}
 Cloudflare Origin CA certificates are only trusted by Cloudflare. Site visitors can get certificate warnings if they connect directly to your Hypernode, if you pause Cloudflare, or if you turn off proxying for a hostname that uses this certificate.
@@ -101,13 +101,13 @@ After applying the SSL certificate, link it to the correct Hypernode. If the cer
 After the certificate is installed and linked in Hypernode, update the SSL/TLS encryption mode in Cloudflare:
 
 ```{note}
-Only set **Full (strict)** globally if all Cloudflare-proxied origin hosts in the zone use a valid Origin CA or publicly trusted certificate. If only this Hypernode uses the Origin CA certificate, configure **Full (strict)** for the relevant hostname in Cloudflare.
+Only set **Full (Strict)** globally if all Cloudflare-proxied origin hosts in the zone use a valid Origin CA or publicly trusted certificate. If only this Hypernode uses the Origin CA certificate, configure **Full (Strict)** for the relevant hostname in Cloudflare.
 ```
 
 1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/).
 1. Select your account and domain.
 1. Go to **SSL/TLS** > **Overview**.
-1. Set **SSL/TLS encryption mode** to **Full (strict)**.
+1. Set **SSL/TLS encryption mode** to **Full (Strict)**.
 
 Test the website through the Cloudflare-proxied hostname after changing this setting.
 

--- a/docs/hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md
+++ b/docs/hypernode-platform/ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md
@@ -1,0 +1,143 @@
+---
+myst:
+  html_meta:
+    description: Add a custom SSL certificate to your Hypernode account and link it
+      to one or more Hypernodes. Includes Cloudflare Origin CA certificates.
+    title: How to use a custom SSL certificate on Hypernode?
+---
+
+# How to Use a Custom SSL Certificate on Hypernode
+
+You can add an SSL certificate from another certificate authority to your Hypernode account via the Control Panel. This is useful when you already have a certificate that was not ordered through Hypernode.
+
+The Control Panel requires the certificate files in PEM format:
+
+- Private Key
+- Certificate
+- Certificate Authority
+
+## Add a Custom SSL Certificate to Your Account
+
+1. Log into your [Control Panel](https://my.hypernode.com/).
+1. Select SSL in the sidebar on the left.
+1. To add a new SSL certificate, click the **Add SSL** button on the right.
+1. Click **Add third party SSL certificate**.
+1. Fill in the Private Key, Certificate and Certificate Authority. Use .PEM files only.
+1. Click **Apply your SSL certificate**.
+1. Click **Details** and then **(Un)link to Hypernodes** to select one or more Hypernodes to link the certificate to.
+
+## Add a Custom SSL Certificate Directly to a Hypernode
+
+You can also add a custom SSL certificate directly to a Hypernode. Follow the steps below to do so:
+
+1. Log into your [Control Panel](https://my.hypernode.com/).
+1. Select the specific Hypernode from the overview.
+1. Click on your **Hypernode** and select **SSL:** under **Services**.
+1. To add a new SSL certificate, click the **Add SSL** button on the right.
+1. Click **Add third party SSL certificate**.
+1. Fill in the Private Key, Certificate and Certificate Authority. Use .PEM files only.
+1. Click **Apply your SSL certificate**.
+
+## Link a Custom SSL Certificate to a Hypernode
+
+If you already have a custom SSL certificate added to your account, you can link it to a specific Hypernode by following these steps:
+
+1. Log into your [Control Panel](https://my.hypernode.com/).
+1. Select the specific Hypernode from the overview.
+1. Click on your **Hypernode** and select **SSL:** under **Services**.
+1. Here you'll see an overview of the available SSL certificates. Click **Details** and then **(Un)link to Hypernodes** to link one or more Hypernodes to link the certificate to.
+
+## Check Which Custom SSL Certificates Are Linked to Your Hypernode
+
+If you want to check which custom SSL certificates are linked to a specific Hypernode, you can do so by following these steps:
+
+1. Log into your [Control Panel](https://my.hypernode.com/).
+1. Select the Hypernode from the overview.
+1. Click on your **Hypernode** and select **SSL:** under **Services**.
+1. You will now see an overview of all linked SSL certificates.
+1. Click **Details** to go the detail page. You can unlink the domain or delete the SSL certificate from here.
+
+## Use a Cloudflare Origin CA Certificate
+
+Cloudflare Origin CA certificates encrypt traffic between Cloudflare and your Hypernode. They are useful when your domain uses Cloudflare proxying and you want to use Cloudflare SSL/TLS mode **Full (strict)**. For more information, see the [official Cloudflare Origin CA documentation](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/).
+
+```{warning}
+Cloudflare Origin CA certificates are only trusted by Cloudflare. Site visitors can get certificate warnings if they connect directly to your Hypernode, if you pause Cloudflare, or if you turn off proxying for a hostname that uses this certificate.
+```
+
+### Create the Certificate in Cloudflare
+
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/).
+1. Select your account and domain.
+1. Go to **SSL/TLS** > **Origin Server**.
+1. On the **Origin Certificates** tab, click **Create Certificate**.
+1. Choose **Generate private key and CSR with Cloudflare**.
+1. Choose **ECC** as the private key type. Hypernode's Nginx and OpenSSL versions support ECC certificates, and ECC keeps the certificate and TLS handshake smaller. Use RSA if you specifically need RSA compatibility.
+1. Add the hostnames the certificate should cover, such as `example.com`, `www.example.com`, or `*.example.com`.
+1. Choose the certificate validity period.
+1. Click **Create**.
+1. Choose **PEM** as the key format.
+1. Copy the **Origin Certificate** and **Private Key** before closing the screen. Cloudflare does not show the private key again later.
+
+### Add the Cloudflare Certificate to Hypernode
+
+Add the certificate as a custom SSL certificate in the Hypernode Control Panel. Use this field mapping:
+
+| Hypernode field       | Cloudflare value                                                            |
+| --------------------- | --------------------------------------------------------------------------- |
+| Private Key           | The **Private Key** shown when you created the Origin CA certificate        |
+| Certificate           | The **Origin Certificate** shown when you created the Origin CA certificate |
+| Certificate Authority | The Cloudflare Origin CA root certificate in PEM format                     |
+
+Use the Cloudflare Origin CA root certificate that matches the certificate type you created:
+
+- [Cloudflare Origin ECC PEM](https://developers.cloudflare.com/ssl/static/origin_ca_ecc_root.pem) for ECC certificates.
+- [Cloudflare Origin RSA PEM](https://developers.cloudflare.com/ssl/static/origin_ca_rsa_root.pem) for RSA certificates.
+
+After applying the SSL certificate, link it to the correct Hypernode. If the certificate was added directly from the Hypernode SSL page, it is already linked to that Hypernode.
+
+### Set Cloudflare to Full (Strict)
+
+After the certificate is installed and linked in Hypernode, update the SSL/TLS encryption mode in Cloudflare:
+
+```{note}
+Only set **Full (strict)** globally if all Cloudflare-proxied origin hosts in the zone use a valid Origin CA or publicly trusted certificate. If only this Hypernode uses the Origin CA certificate, configure **Full (strict)** for the relevant hostname in Cloudflare.
+```
+
+1. Log into the [Cloudflare dashboard](https://dash.cloudflare.com/).
+1. Select your account and domain.
+1. Go to **SSL/TLS** > **Overview**.
+1. Set **SSL/TLS encryption mode** to **Full (strict)**.
+
+Test the website through the Cloudflare-proxied hostname after changing this setting.
+
+## How to Generate a Certificate Signing Request on Nginx Using OpenSSL
+
+Log into your Hypernode with SSH and run the following command:
+
+```bash
+openssl req -new -newkey rsa:2048 -nodes -keyout myserver.key -out myserver.csr
+```
+
+```{note}
+Replace `myserver` with the domain name you're securing. For example, if your domain name is `mydomain.com`, use `mydomain.key` and `mydomain.csr`.
+```
+
+This command creates two files: the private key file for decrypting the SSL certificate and the certificate signing request (CSR) file used to apply for your SSL certificate.
+
+Enter the requested information:
+
+- **Common Name (CN):** The fully-qualified domain name, or URL, you want to secure.
+- **Organization (O):** The legally registered name for your business. If you are enrolling as an individual, enter the certificate requestor's name.
+- **Organization Unit (OU):** If applicable, enter the DBA (Doing Business As) name.
+- **City or Locality (L):** Name of the city where your organization is registered or located. Do not abbreviate.
+- **State or Province (S):** Name of the state or province where your organization is located. Do not abbreviate.
+- **Country (C):** The two-letter International Organization for Standardization (ISO) country code for where your organization is legally registered.
+
+If you are requesting a wildcard certificate, add an asterisk (`*`) to the left of the common name where you want the wildcard, for example `*.mydomain.com`. Do not use the asterisk in the private key or CSR file names, because `*` is a special character in shells. Use file names like `wildcard.mydomain.com.key` and `wildcard.mydomain.com.csr` instead.
+
+If you do not want to enter a password for this SSL certificate, leave the passphrase field blank.
+
+Your `.csr` file will then be created. Open the CSR file with a text editor and copy and paste it, including the `BEGIN` and `END` tags, into the certificate order form.
+
+Save the generated `.key` file. You will need it when installing your SSL certificate in Nginx.

--- a/docs/hypernode-platform/ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-hypernode-com.md
+++ b/docs/hypernode-platform/ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-hypernode-com.md
@@ -21,7 +21,7 @@ SSL sends information across the internet encrypted so that only the intended re
 When you have ordered your Hypernode on Hypernode.com you have three options to use SSL on your Hypernode plan(s):
 
 - Buy an SSL certificate via Hypernode.
-- Upload your own SSL certificate
+- [Upload your own SSL certificate](../ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md)
 - Request a certificate using Let’s Encrypt
 
 ## Buy an SSL Certificate Via Hypernode (Recommended)
@@ -59,53 +59,9 @@ Please note! To avoid being charged for another year, please make sure to cancel
 
 If the certificate has already been renewed, Hypernode has already incurred costs for the renewal of the SSL certificate. Approving or not approving this request does not change that. The costs for the certificate will be added to the upcoming invoice.
 
-## Add a Third Party SSL Certificate to Your Account
+## Upload Your Own SSL Certificate
 
-You can add your SSL certificate to your account via your Control Panel. Follow the steps below:
-
-1. Log into your [Control Panel](https://my.hypernode.com/).
-1. Select SSL in the sidebar on the left:
-   ![SSL side bar screenshot](_res/sidebar-ssl-selection.png)
-1. To add a new SSL certificate, click the **Add SSL** button on the right.
-1. Click **Add third party SSL certificate**.
-1. Fill in the Private Key, Certificate and Certificate Authority (only .PEM files).
-1. Click **Apply your SSL certificate**. You'll then go to this page:
-   ![SSL certificates page screenshot](_res/ssl-certificate-page.png)
-1. Click **Details** and then **(Un)link to Hypernodes** to select one or more Hypernodes to link the certificate to.
-
-### Add a Third Party SSL Certificate Directly to a Hypernode
-
-You can also add a third pardy SSL certificate directly to a Hypernode. Follow the steps below to do so:
-
-1. Log into your [Control Panel](https://my.hypernode.com/).
-1. Select the specific Hypernode from the overview.
-1. Click on your **Hypernode** and click **SSL:** under **Services**.
-   ![SSL side bar list screenshot](_res/sidebar-list.png)
-1. To add a new SSL certificate, click the **Add SSL** button on the right.
-1. Click **Add third party SSL certificate**.
-1. Fill in the Private Key, Certificate and Certificate Authority (only .PEM files).
-1. Click **Apply your SSL certificate**.
-
-### Link a Third Party SSL Certificate to a Hypernode
-
-If you already have a third party SSL added to your account, you can link it to a specific Hypernode by following these steps:
-
-1. Log into your [Control Panel](https://my.hypernode.com/).
-1. Select the specific Hypernode from the overview.
-1. Click on your **Hypernode** and click **SSL:** under **Services**.
-   ![SSL side bar list screenshot](_res/sidebar-list.png)
-1. Here you'll see an overview of the available SSL certificates. Click **Details** and then **(Un)link to Hypernodes** to link one or more Hypernodes to link the certificate to.
-
-### Check Which Third Party Certificates Are Linked to Your Hypernode
-
-If you want to check which Third Party certificates are linked to a specific Hypernode, you can do so by following these steps:
-
-1. Log into your [Control Panel](https://my.hypernode.com/).
-1. Select the Hypernode from the overview.
-1. Click on your **Hypernode** and click **SSL:** under **Services**.
-   ![SSL side bar list screenshot](_res/sidebar-list.png)
-1. You will now see an overview of all linked SSL certificates.
-1. Click **Details** to go the detail page. You can unlink the domain or delete the SSL certificate from here.
+If you already have an SSL certificate from another certificate authority, follow [How to Use a Custom SSL Certificate on Hypernode](../ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md).
 
 ## Use Let’s Encrypt
 
@@ -208,39 +164,3 @@ After configuring your shop to only use HTTPS, please do not forget to check HTT
 - Payment providers like Adyen
 - Stock providers like Picqer
 - Google Analytics and Google Search Console
-
-## How to Generate Certificate Signing Request on Nginx using OpenSSL
-
-Log into your Hypernode with SSH and run the following command:
-
-```bash
-openssl req -new -newkey rsa:2048 -nodes -keyout myserver.key -out myserver.csr
-```
-
-**Note:** Replace yourdomain with the domain name you're securing. For example, if your domain name is mydomain.com, you would type mydomain.key and mydomain.csr where server is the name of your server.
-
-This will begin the process of generating two files: the Private-Key file for the decryption of your SSL Certificate, and a certificate signing request (CSR) file used to apply for your SSL Certificate.
-
-Enter the requested information:
-
-**- Common Name (CN):** The fully-qualified domain name, or URL, you want to secure.
-
-If you are requesting a Wildcard certificate, add an asterisk (\*) to the left of the common name where you want the wildcard, for example `*.mydomain.com`.
-
-**- Organization (O):** The legally-registered name for your business. If you are enrolling as an individual, enter the certificate requestor's name.
-
-**- Organization Unit (OU):** If applicable, enter the DBA (Doing Business As) name.
-
-**- City or Locality (L):** Name of the city where your organization is registered/located. Do not abbreviate.
-
-**- State or Province (S):** Name of the state or province where your organization is located. Do not abbreviate.
-
-**- Country (C):** The two-letter International Organization for Standardization (ISO) format country code for where your organization is legally registered.
-
-**Note:** If you do not want to enter a password for this SSL, you can leave the Passphrase field blank.
-
-Your `.csr` file will then be created.
-
-Open the CSR file with a text editor and copy and paste it (including the BEGIN and END tags) into the Certificate order form.
-
-Save (backup) the generated .key file as it will be required later when installing your SSL certificate in Nginx.

--- a/docs/hypernode-platform/ssl/how-to-validate-your-ssl-certificate-and-more-frequently-asked-questions-about-ssl.md
+++ b/docs/hypernode-platform/ssl/how-to-validate-your-ssl-certificate-and-more-frequently-asked-questions-about-ssl.md
@@ -38,7 +38,7 @@ The costs for an SSL certificate consist of two aspects: the costs for the actua
 
 The certificate costs you pay for an SSL certificate that you order via Hypernode, is the purchase prise we pay at our supplier. We arrange the entire SSL application for you. You do not have to do anything more than to order the certificate in your Service Panel. Only with EV-SSL you still have to take care of a number of things (as explained [here](#what-kind-of-certificates-can-i-order-via-hypernode)).
 
-In the background, the certificate is requested with the correct data, the validation is done (place file, perform validation), the certificate is retrieved and safely stored in the right place. We ensure that your SSL certificate works properly, even if you change your plan. All you have to take care of is to link the SSL certificate to the right Hypernode (which can be done with [one click](../ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-hypernode-com.md#link-a-third-party-ssl-certificate-to-a-hypernode)).
+In the background, the certificate is requested with the correct data, the validation is done (place file, perform validation), the certificate is retrieved and safely stored in the right place. We ensure that your SSL certificate works properly, even if you change your plan. All you have to take care of is to link the SSL certificate to the right Hypernode (which can be done with [one click](../ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md#link-a-custom-ssl-certificate-to-a-hypernode)).
 
 ### Your SSL Certificate Is Automatically Renewed
 
@@ -114,4 +114,4 @@ Make sure there are no more redirects to the HTTPS version of your site.
 
 ## Can I Use My Own SSL Certificate?
 
-You can also use a (custom) SSL certificate you purchased elsewhere on a Hypernode. You can find out how to install this on your Hypernode [here](../ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-hypernode-com.md#add-a-third-party-ssl-certificate-to-your-account).
+You can also use a (custom) SSL certificate you purchased elsewhere on a Hypernode. You can find out how to install this on your Hypernode [here](../ssl/how-to-use-a-custom-ssl-certificate-on-hypernode.md#add-a-custom-ssl-certificate-to-your-account).

--- a/docs/hypernode-platform/ssl/how-to-validate-your-ssl-certificate-and-more-frequently-asked-questions-about-ssl.md
+++ b/docs/hypernode-platform/ssl/how-to-validate-your-ssl-certificate-and-more-frequently-asked-questions-about-ssl.md
@@ -9,19 +9,15 @@ redirect_from:
   - /en/hypernode/ssl/how-to-validate-your-ssl-certificate-and-more-frequently-asked-questions-about-ssl/
 ---
 
-<!-- source: https://support.hypernode.com/en/hypernode/ssl/how-to-validate-your-ssl-certificate-and-more-frequently-asked-questions-about-ssl/ -->
-
 # How to Validate Your SSL Certificate and More Frequently Asked Questions About SSL
-
-**Please note that this only applies to Service Panel users who log in via service.byte.nl.**
 
 ## What Kind of Certificates Can I Order via Hypernode?
 
-At Hypernode you can request various SSL certificates via the [Service Panel](https://my.hypernode.com/login/). There are three types of certificates:
+At Hypernode you can request various SSL certificates via the [Control Panel](https://my.hypernode.com/login/). There are three types of certificates:
 
-- SSL single certificate; you can use this on a single domain for the naked domain and the www domain (example.com and [www.example.com](http://www.example.com)).
-- SSL wildcard certificate; You can use this to secure all subdomains (\* .example.nl) for your domain name, but also on [www.example.nl](http://www.example.nl) and the naked domain (ie example.nl). However, this certificate does not work on \*. \*. example.nl.
-- EV-SSL certificate; you can only use this on the main domain (example.nl). EV stands for Extended Validation and gives you the reliable green bar, known from many bank websites. In terms of technology, an EV-SSL certificate does not differ from the "normal" SSL certificates, but the difference is in the identity investigation. With an EV-SSL certificate, extensive research is done into the identity of the applicant. In that sense, an EV-SSL certificate is "worth" more or more reliable. The contract period for all SSL certificates is one year.
+- SSL single certificate; you can use this on a single domain for the naked domain and the www domain (`example.com` and `www.example.com`).
+- SSL wildcard certificate; You can use this to secure all subdomains (`*.example.nl`) for your domain name, but also on `www.example.nl` and the naked domain (ie `example.nl`). However, this certificate does not work on `*.*.example.nl`.
+- EV-SSL certificate; you can only use this on the main domain (`example.nl`). EV stands for Extended Validation. In terms of technology, an EV-SSL certificate does not differ from the "normal" SSL certificates, but the difference is in the identity investigation. With an EV-SSL certificate, extensive research is done into the identity of the applicant. In that sense, an EV-SSL certificate is "worth" more or more reliable. The contract period for all SSL certificates is one year.
 
 Please take into account that it can take a few days to apply for an SSL certificate. This mainly applies to EV SSL certificates for which the applicant needs to show that they have control over the domain for which the certificate was requested, the company data als needs to be verified. To do so, our supplier (Sectigo) looks at a public registry, such as that of the Chamber of Commerce, and they contact the organisation by phone. EV certificates also require documents to be signed and submitted to our supplier.
 
@@ -29,12 +25,11 @@ Please take into account that it can take a few days to apply for an SSL certifi
 
 The costs for an SSL certificate consist of two aspects: the costs for the actual certificate and the service costs for the certificate.
 
-|          |                       |                   |           |
-| -------- | --------------------- | ----------------- | --------- |
-| **Type** | **Certificate costs** | **Service costs** | **Total** |
-| Single   | € 8,00                | € 30,00           | € 38,00   |
-| Wildcard | € 75,00               | € 80,00           | € 155,00  |
-| EV       | € 95,00               | € 80,00           | € 175,00  |
+| Type     | Certificate costs | Service costs | Total    |
+| -------- | ----------------- | ------------- | -------- |
+| Single   | € 8,00            | € 30,00       | € 38,00  |
+| Wildcard | € 75,00           | € 80,00       | € 155,00 |
+| EV       | € 95,00           | € 80,00       | € 175,00 |
 
 The certificate costs you pay for an SSL certificate that you order via Hypernode, is the purchase prise we pay at our supplier. We arrange the entire SSL application for you. You do not have to do anything more than to order the certificate in your Service Panel. Only with EV-SSL you still have to take care of a number of things (as explained [here](#what-kind-of-certificates-can-i-order-via-hypernode)).
 
@@ -86,29 +81,21 @@ You can order an SSL certificate in the Control Panel. You can find out how to d
 
 ## How Can I Link the SSL Certificate to the Hypernode?
 
-As soon as your SSL certificate has been issued you can install it on your Hypernode.
+As soon as your SSL certificate has been issued you can link it on your Hypernode.
 
-You do this via the Service Panel.
-
-1. Select your Hypernode in the Service Panel
-1. Go to the **Instellingen** tab and then to **SSL & DNS Instellingen**
-1. You will see all domains of which you are a Contracting Party. The domain for which you ordered an SSL certificate has the status "Beschikbaar" in the "SSL-certificaat" column. Click on **installeren**to install the SSL certificate on your Hypernode.
-
-Repeat this for other domains/store fronts if necessary.
+Follow our [How to use SSL certificates on your Hypernode](../ssl/how-to-use-ssl-certificates-on-your-hypernode-when-ordered-via-hypernode-com.md) article.
 
 ## How Can I Cancel My SSL Certificate?
 
-Do you no longer want to use a secure connection for your website? Then you can always cancel the certificate via the Service Panel. Follow the steps below:
+Do you no longer want to use a secure connection for your website? Then you can always cancel the certificate via the Control Panel. Follow the steps below:
 
-- Login to the Service Panel
-- Select your domain name.
-- Click the **Administratief**tab.
-- Click on the**SSL Certificaat**option.
-- At the bottom you can indicate that you wish to cancel the certificate (**SSL-certificaat opzeggen**). This can be done immediately or at the end of the contract.
+1. Login to the Control Panel
+1. Select SSL in the sidebar on the left.
+1. Select your SSL certificate.
+1. Click **Delete this third-party SSL certificate**.
+1. Click **Delete this SSL certificate**.
 
-If you cancel immediately and you do not have another SSL installed, keep the following in mind:
-
-Make sure your site can work without SSL: there should no longer be references to HTTPS in your site.
+Make sure your site can work without this SSL certificate: there should no longer be references to HTTPS in your site.
 
 Make sure there are no more redirects to the HTTPS version of your site.
 


### PR DESCRIPTION
Split the generic custom certificate instructions into a dedicated article so users can find the Control Panel flow directly.

Add a Cloudflare Origin CA section with Hypernode-specific field mapping, certificate type guidance, and notes for strict SSL mode. Update the existing SSL overview, FAQ, and Cloudflare article to point at the new guide.